### PR TITLE
fix: support Optional<T> for nullable fields in insert and upsert (#38)

### DIFF
--- a/tests/type/models.py
+++ b/tests/type/models.py
@@ -118,8 +118,21 @@ class JSONModel(models.Model):
 
 
 class NullableJSONModel(models.Model):
-    # Used by tests skipped under issue #38 (nullable parameter typing).
     data = models.JSONField(null=True, blank=True)
 
     def __str__(self):
         return str(self.data)
+
+
+class NullableFieldsModel(models.Model):
+    char_field = models.CharField(max_length=100, null=True, blank=True)  # noqa: DJ001
+    int_field = models.IntegerField(null=True)
+    big_int_field = models.BigIntegerField(null=True)
+    float_field = models.FloatField(null=True)
+    bool_field = models.BooleanField(null=True)
+    date_field = models.DateField(null=True)
+    datetime_field = models.DateTimeField(null=True)
+    text_field = models.TextField(null=True, blank=True)  # noqa: DJ001
+
+    def __str__(self):
+        return f"NullableFieldsModel({self.pk})"

--- a/tests/type/test_json_field.py
+++ b/tests/type/test_json_field.py
@@ -1,14 +1,7 @@
-import unittest
-
 from django.test import SimpleTestCase
 
 from .models import JSONModel
 from .models import NullableJSONModel
-
-# Skipped until issue #38 (nullable parameter typing) is resolved.
-# _get_data_type() emits bare PrimitiveType.Json; sending NULL requires
-# Optional<Json> in the YDB struct declaration.
-_SKIP_NULLABLE = unittest.skip("blocked by issue #38: nullable JSON not yet supported")
 
 
 class JSONFieldTest(SimpleTestCase):
@@ -56,13 +49,15 @@ class JSONFieldTest(SimpleTestCase):
         obj.refresh_from_db()
         self.assertEqual(obj.data, {"v": 2, "new": "field"})
 
-    @_SKIP_NULLABLE
+
+class NullableJSONFieldTest(SimpleTestCase):
+    databases = {"default"}
+
     def test_null_stored_as_sql_null(self):
         obj = NullableJSONModel.objects.create(data=None)
         fetched = NullableJSONModel.objects.get(pk=obj.pk)
         self.assertIsNone(fetched.data)
 
-    @_SKIP_NULLABLE
     def test_isnull_filter(self):
         NullableJSONModel.objects.create(data=None)
         NullableJSONModel.objects.create(data={"x": 1})

--- a/tests/type/test_nullable_fields.py
+++ b/tests/type/test_nullable_fields.py
@@ -83,6 +83,10 @@ class NullableFieldsTest(TransactionTestCase):
         self.assertAlmostEqual(fetched.float_field, 3.14, places=5)
         self.assertIs(fetched.bool_field, True)
         self.assertEqual(fetched.date_field, datetime.date(2024, 6, 15))
+        self.assertEqual(
+            fetched.datetime_field,
+            datetime.datetime(2024, 6, 15, 12, 0, 0),  # noqa: DTZ001
+        )
         self.assertEqual(fetched.text_field, "long text")
 
     def test_isnull_filter(self):

--- a/tests/type/test_nullable_fields.py
+++ b/tests/type/test_nullable_fields.py
@@ -1,12 +1,11 @@
 import datetime
 
-from django.test import SimpleTestCase
+from django.test import TransactionTestCase
 
 from .models import NullableFieldsModel
 
 
-class NullableFieldsTest(SimpleTestCase):
-    databases = {"default"}
+class NullableFieldsTest(TransactionTestCase):
 
     def _create_all_null(self):
         return NullableFieldsModel.objects.create(
@@ -89,9 +88,9 @@ class NullableFieldsTest(SimpleTestCase):
     def test_isnull_filter(self):
         self._create_all_null()
         NullableFieldsModel.objects.create(int_field=1)
-        self.assertGreaterEqual(
+        self.assertEqual(
             NullableFieldsModel.objects.filter(int_field__isnull=True).count(), 1
         )
-        self.assertGreaterEqual(
+        self.assertEqual(
             NullableFieldsModel.objects.filter(int_field__isnull=False).count(), 1
         )

--- a/tests/type/test_nullable_fields.py
+++ b/tests/type/test_nullable_fields.py
@@ -1,0 +1,97 @@
+import datetime
+
+from django.test import SimpleTestCase
+
+from .models import NullableFieldsModel
+
+
+class NullableFieldsTest(SimpleTestCase):
+    databases = {"default"}
+
+    def _create_all_null(self):
+        return NullableFieldsModel.objects.create(
+            char_field=None,
+            int_field=None,
+            big_int_field=None,
+            float_field=None,
+            bool_field=None,
+            date_field=None,
+            datetime_field=None,
+            text_field=None,
+        )
+
+    def test_all_null_roundtrip(self):
+        obj = self._create_all_null()
+        fetched = NullableFieldsModel.objects.get(pk=obj.pk)
+        self.assertIsNone(fetched.char_field)
+        self.assertIsNone(fetched.int_field)
+        self.assertIsNone(fetched.big_int_field)
+        self.assertIsNone(fetched.float_field)
+        self.assertIsNone(fetched.bool_field)
+        self.assertIsNone(fetched.date_field)
+        self.assertIsNone(fetched.datetime_field)
+        self.assertIsNone(fetched.text_field)
+
+    def test_char_field_null(self):
+        obj = NullableFieldsModel.objects.create(char_field=None)
+        self.assertIsNone(NullableFieldsModel.objects.get(pk=obj.pk).char_field)
+
+    def test_int_field_null(self):
+        obj = NullableFieldsModel.objects.create(int_field=None)
+        self.assertIsNone(NullableFieldsModel.objects.get(pk=obj.pk).int_field)
+
+    def test_big_int_field_null(self):
+        obj = NullableFieldsModel.objects.create(big_int_field=None)
+        self.assertIsNone(NullableFieldsModel.objects.get(pk=obj.pk).big_int_field)
+
+    def test_float_field_null(self):
+        obj = NullableFieldsModel.objects.create(float_field=None)
+        self.assertIsNone(NullableFieldsModel.objects.get(pk=obj.pk).float_field)
+
+    def test_bool_field_null(self):
+        obj = NullableFieldsModel.objects.create(bool_field=None)
+        self.assertIsNone(NullableFieldsModel.objects.get(pk=obj.pk).bool_field)
+
+    def test_date_field_null(self):
+        obj = NullableFieldsModel.objects.create(date_field=None)
+        self.assertIsNone(NullableFieldsModel.objects.get(pk=obj.pk).date_field)
+
+    def test_datetime_field_null(self):
+        obj = NullableFieldsModel.objects.create(datetime_field=None)
+        self.assertIsNone(NullableFieldsModel.objects.get(pk=obj.pk).datetime_field)
+
+    def test_text_field_null(self):
+        obj = NullableFieldsModel.objects.create(text_field=None)
+        self.assertIsNone(NullableFieldsModel.objects.get(pk=obj.pk).text_field)
+
+    def test_non_null_values_roundtrip(self):
+        obj = NullableFieldsModel.objects.create(
+            char_field="hello",
+            int_field=-42,
+            big_int_field=10**15,
+            float_field=3.14,
+            bool_field=True,
+            date_field=datetime.date(2024, 6, 15),
+            datetime_field=datetime.datetime(
+                2024, 6, 15, 12, 0, 0, tzinfo=datetime.timezone.utc
+            ),
+            text_field="long text",
+        )
+        fetched = NullableFieldsModel.objects.get(pk=obj.pk)
+        self.assertEqual(fetched.char_field, "hello")
+        self.assertEqual(fetched.int_field, -42)
+        self.assertEqual(fetched.big_int_field, 10**15)
+        self.assertAlmostEqual(fetched.float_field, 3.14, places=5)
+        self.assertIs(fetched.bool_field, True)
+        self.assertEqual(fetched.date_field, datetime.date(2024, 6, 15))
+        self.assertEqual(fetched.text_field, "long text")
+
+    def test_isnull_filter(self):
+        self._create_all_null()
+        NullableFieldsModel.objects.create(int_field=1)
+        self.assertGreaterEqual(
+            NullableFieldsModel.objects.filter(int_field__isnull=True).count(), 1
+        )
+        self.assertGreaterEqual(
+            NullableFieldsModel.objects.filter(int_field__isnull=False).count(), 1
+        )

--- a/ydb_backend/models/sql/compiler.py
+++ b/ydb_backend/models/sql/compiler.py
@@ -152,13 +152,14 @@ def _get_data(fields, param_rows):
     for i in range(len(param_rows)):
         struct = {}
         for j in range(len(fields)):
-            if _get_field_internal_type(fields[j]) == "DateTimeField":
-                val = param_rows[i][j]
+            val = param_rows[i][j]
+            is_dt = _get_field_internal_type(fields[j]) == "DateTimeField"
+            if is_dt and val is not None:
                 struct[fields[j].column] = (
                     val if isinstance(val, int) else int(val.timestamp())
                 )
             else:
-                struct[fields[j].column] = param_rows[i][j]
+                struct[fields[j].column] = val
         result.append(struct)
 
     return result
@@ -167,7 +168,10 @@ def _get_data(fields, param_rows):
 def _get_data_type(fields):
     struct_type = ydb.StructType()
     for f in fields:
-        struct_type.add_member(f.column, _ydb_types[_get_field_internal_type(f)])
+        ydb_type = _ydb_types[_get_field_internal_type(f)]
+        if getattr(f, "null", False):
+            ydb_type = ydb.OptionalType(ydb_type)
+        struct_type.add_member(f.column, ydb_type)
     return ydb.ListType(struct_type)
 
 
@@ -382,12 +386,14 @@ class BaseSQLWriteCompiler(compiler.SQLInsertCompiler):
         opts = self.query.get_meta()
         fields = self.query.fields or [opts.pk]
 
-        field_types = [
-            qn(f.column) + ": " + self.connection.introspection.get_field_type(
+        field_types = []
+        for f in fields:
+            yql_type = self.connection.introspection.get_field_type(
                 _get_field_internal_type(f), {}
             )
-            for f in fields
-        ]
+            if getattr(f, "null", False):
+                yql_type = f"Optional<{yql_type}>"
+            field_types.append(f"{qn(f.column)}: {yql_type}")
         in_ = f"{', '.join(field_types)}"
 
         return [


### PR DESCRIPTION
## Summary

- Wrap YDB parameter types with `OptionalType`/`Optional<T>` in `_get_data_type()` and `_prepare_sql_statement()` when a field has `null=True`, so `NULL` values can be passed in parameterized insert/upsert statements
- Fix `_get_data()` to skip the `DateTimeField` timestamp conversion when the value is `None`
- Remove the `@skip` markers from nullable JSON tests — they now pass

Closes #38.

## Test plan

- [x] `poetry run python tests/runtests.py type.test_json_field -v 2` — all 10 tests pass including nullable ones
- [x] `poetry run python tests/runtests.py` — all 117 tests pass
- [x] `poetry run ruff check` — no lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)