### PR TITLE
fix: audit and correct DatabaseFeatures flags, implement COVER syntax, add tests

### DIFF
--- a/tests/backends/ydb/test_features.py
+++ b/tests/backends/ydb/test_features.py
@@ -1,0 +1,340 @@
+"""
+Tests for DatabaseFeatures: flag values and behavioral verification.
+
+Flag assertions document what YDB supports. Integration tests verify that
+the flags accurately reflect live database behavior.
+"""
+from django.db import connection
+from django.db import models
+from django.db.models import Sum
+from django.db.models import Window
+from django.db.models.expressions import RowRange
+from django.db.models.expressions import ValueRange
+from django.db.utils import NotSupportedError
+from django.test import SimpleTestCase
+from django.test import TransactionTestCase
+
+# ---------------------------------------------------------------------------
+# Flag value assertions (no live DB required)
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureFlags(SimpleTestCase):
+    """Every explicit DatabaseFeatures override is asserted here."""
+
+    # --- GROUP BY ---
+    def test_allows_group_by_selected_pks(self):
+        self.assertTrue(connection.features.allows_group_by_selected_pks)
+
+    def test_no_group_by_select_index(self):
+        # YDB rejects "GROUP BY 1" ordinal references.
+        self.assertFalse(connection.features.allows_group_by_select_index)
+
+    # --- UPDATE / DELETE self-reference ---
+    def test_no_update_self_select(self):
+        self.assertFalse(connection.features.update_can_self_select)
+
+    def test_no_delete_self_reference_subquery(self):
+        self.assertFalse(connection.features.delete_can_self_reference_subquery)
+
+    # --- NULL / string semantics ---
+    def test_does_not_interpret_empty_strings_as_nulls(self):
+        self.assertFalse(connection.features.interprets_empty_strings_as_nulls)
+
+    def test_ignores_table_name_case(self):
+        self.assertTrue(connection.features.ignores_table_name_case)
+
+    # --- Unique / nullable constraints ---
+    def test_no_nullable_unique_constraints(self):
+        self.assertFalse(connection.features.supports_nullable_unique_constraints)
+
+    def test_no_partially_nullable_unique_constraints(self):
+        self.assertFalse(
+            connection.features.supports_partially_nullable_unique_constraints
+        )
+
+    # --- Bulk insert ---
+    def test_no_bulk_insert_return_rows(self):
+        self.assertFalse(connection.features.can_return_rows_from_bulk_insert)
+
+    # --- Transactions / savepoints ---
+    def test_transactions_supported(self):
+        self.assertTrue(connection.features.supports_transactions)
+
+    def test_no_savepoints(self):
+        self.assertFalse(connection.features.uses_savepoints)
+
+    # --- References ---
+    def test_no_forward_references(self):
+        self.assertFalse(connection.features.supports_forward_references)
+
+    # --- Native types ---
+    def test_native_uuid_field(self):
+        self.assertTrue(connection.features.has_native_uuid_field)
+
+    def test_native_duration_field(self):
+        self.assertTrue(connection.features.has_native_duration_field)
+
+    def test_temporal_subtraction_supported(self):
+        self.assertTrue(connection.features.supports_temporal_subtraction)
+
+    # --- Regex ---
+    def test_no_regex_backreferencing(self):
+        self.assertFalse(connection.features.supports_regex_backreferencing)
+
+    # --- Timezone data ---
+    def test_no_zoneinfo_database(self):
+        self.assertFalse(connection.features.has_zoneinfo_database)
+
+    # --- ORDER BY ---
+    def test_no_order_by_nulls_modifier(self):
+        self.assertFalse(connection.features.supports_order_by_nulls_modifier)
+
+    # --- Auto PK ---
+    def test_no_auto_pk_0(self):
+        self.assertFalse(connection.features.allows_auto_pk_0)
+
+    def test_no_sequence_reset(self):
+        self.assertFalse(connection.features.supports_sequence_reset)
+
+    # --- Introspection ---
+    def test_no_introspect_default(self):
+        self.assertFalse(connection.features.can_introspect_default)
+
+    def test_no_introspect_foreign_keys(self):
+        self.assertFalse(connection.features.can_introspect_foreign_keys)
+
+    def test_no_introspect_check_constraints(self):
+        self.assertFalse(connection.features.can_introspect_check_constraints)
+
+    def test_no_introspect_json_field(self):
+        self.assertFalse(connection.features.can_introspect_json_field)
+
+    # --- Schema / DDL ---
+    def test_schema_editor_clientside_param_binding(self):
+        self.assertTrue(connection.features.schema_editor_uses_clientside_param_binding)
+
+    def test_no_foreign_keys(self):
+        self.assertFalse(connection.features.supports_foreign_keys)
+
+    def test_no_inline_fk(self):
+        self.assertFalse(connection.features.can_create_inline_fk)
+
+    def test_no_auto_index_foreign_keys(self):
+        self.assertFalse(connection.features.indexes_foreign_keys)
+
+    def test_no_column_check_constraints(self):
+        self.assertFalse(connection.features.supports_column_check_constraints)
+
+    def test_no_table_check_constraints(self):
+        self.assertFalse(connection.features.supports_table_check_constraints)
+
+    def test_no_expression_defaults(self):
+        self.assertFalse(connection.features.supports_expression_defaults)
+
+    def test_no_default_keyword_in_insert(self):
+        self.assertFalse(connection.features.supports_default_keyword_in_insert)
+
+    def test_no_default_keyword_in_bulk_insert(self):
+        self.assertFalse(connection.features.supports_default_keyword_in_bulk_insert)
+
+    # --- SELECT FOR UPDATE ---
+    def test_no_select_for_update_with_limit(self):
+        self.assertFalse(connection.features.supports_select_for_update_with_limit)
+
+    # --- Compound queries ---
+    def test_no_select_intersection(self):
+        self.assertFalse(connection.features.supports_select_intersection)
+
+    def test_no_select_difference(self):
+        self.assertFalse(connection.features.supports_select_difference)
+
+    def test_no_parentheses_in_compound(self):
+        self.assertFalse(connection.features.supports_parentheses_in_compound)
+
+    # --- Window functions ---
+    def test_over_clause_supported(self):
+        self.assertTrue(connection.features.supports_over_clause)
+
+    def test_only_unbounded_range_frames(self):
+        # YDB RANGE frames only work with UNBOUNDED PRECEDING/FOLLOWING.
+        # Bounded RANGE (e.g. RANGE BETWEEN 1 PRECEDING AND CURRENT ROW) fails.
+        self.assertTrue(
+            connection.features.only_supports_unbounded_with_preceding_and_following
+        )
+
+    # --- Conflicts ---
+    def test_no_ignore_conflicts(self):
+        self.assertFalse(connection.features.supports_ignore_conflicts)
+
+    # --- Indexes ---
+    def test_no_partial_indexes(self):
+        self.assertFalse(connection.features.supports_partial_indexes)
+
+    def test_no_functions_in_partial_indexes(self):
+        self.assertFalse(connection.features.supports_functions_in_partial_indexes)
+
+    def test_covering_indexes_supported(self):
+        self.assertTrue(connection.features.supports_covering_indexes)
+
+    def test_no_expression_indexes(self):
+        self.assertFalse(connection.features.supports_expression_indexes)
+
+    def test_no_multiple_constraints_same_fields(self):
+        self.assertFalse(connection.features.allows_multiple_constraints_on_same_fields)
+
+    # --- JSON ---
+    def test_native_json_field(self):
+        self.assertTrue(connection.features.has_native_json_field)
+
+    def test_json_key_contains_list_matching_requires_list(self):
+        self.assertTrue(
+            connection.features.json_key_contains_list_matching_requires_list
+        )
+
+    def test_no_json_object_function(self):
+        self.assertFalse(connection.features.has_json_object_function)
+
+    # --- Collation ---
+    def test_no_collation_on_charfield(self):
+        self.assertFalse(connection.features.supports_collation_on_charfield)
+
+    def test_no_collation_on_textfield(self):
+        self.assertFalse(connection.features.supports_collation_on_textfield)
+
+    def test_no_non_deterministic_collations(self):
+        self.assertFalse(connection.features.supports_non_deterministic_collations)
+
+    # --- Bounded RANGE frame raises NotSupportedError at Django level ---
+    def test_bounded_range_frame_raises_not_supported(self):
+        with self.assertRaises(NotSupportedError):
+            connection.ops.window_frame_range_start_end(start=-1, end=0)
+
+    def test_bounded_range_following_raises_not_supported(self):
+        with self.assertRaises(NotSupportedError):
+            connection.ops.window_frame_range_start_end(start=None, end=1)
+
+    def test_unbounded_range_frame_is_allowed(self):
+        start, end = connection.ops.window_frame_range_start_end(start=None, end=0)
+        self.assertEqual(start, "UNBOUNDED PRECEDING")
+        self.assertEqual(end, "CURRENT ROW")
+
+    def test_bounded_rows_frame_is_allowed(self):
+        # ROWS frames are fine with bounded offsets.
+        start, end = connection.ops.window_frame_rows_start_end(start=-1, end=0)
+        self.assertEqual(start, "1 PRECEDING")
+        self.assertEqual(end, "CURRENT ROW")
+
+
+# ---------------------------------------------------------------------------
+# Window function ORM integration tests
+# ---------------------------------------------------------------------------
+
+
+class WindowTestModel(models.Model):
+    id = models.IntegerField(primary_key=True)
+    bounty = models.IntegerField()
+
+    class Meta:
+        app_label = "backends"
+        db_table = "ydb_feat_window"
+        managed = False
+
+    def __str__(self):
+        return str(self.id)
+
+
+class TestWindowFunctions(TransactionTestCase):
+    databases = {"default"}
+
+    def setUp(self):
+        try:
+            with connection.schema_editor() as ed:
+                ed.delete_model(WindowTestModel)
+        except Exception:  # noqa: BLE001
+            pass
+        with connection.schema_editor() as ed:
+            ed.create_model(WindowTestModel)
+
+    def tearDown(self):
+        try:
+            with connection.schema_editor() as ed:
+                ed.delete_model(WindowTestModel)
+        except Exception:  # noqa: BLE001
+            pass
+        super().tearDown()
+
+    def _insert(self, pk, bounty):
+        WindowTestModel.objects.create(id=pk, bounty=bounty)
+
+    def test_unbounded_rows_frame_cumulative_sum(self):
+        # Default: no explicit frame → OVER (ORDER BY id).
+        self._insert(pk=1, bounty=30_000_000)   # Luffy
+        self._insert(pk=2, bounty=320_000_000)  # Zoro
+        self._insert(pk=3, bounty=66_000_000)   # Nami
+
+        table = WindowTestModel._meta.db_table
+        qs = (
+            WindowTestModel.objects
+            .annotate(running=Window(Sum("bounty"), order_by="id"))
+            .values_list("id", "running")
+            .order_by("id")
+        )
+        self.assertEqual(
+            str(qs.query),
+            f"SELECT `{table}`.`id` AS `id`, SUM(`{table}`.`bounty`) OVER"
+            f" (ORDER BY `{table}`.`id`) AS `running`"
+            f" FROM `{table}` ORDER BY `{table}`.`id` ASC",
+        )
+
+        rows = list(qs)
+        self.assertEqual(rows[0][1], 30_000_000)
+        self.assertEqual(rows[1][1], 350_000_000)
+        self.assertEqual(rows[2][1], 416_000_000)
+
+    def test_bounded_rows_preceding_frame(self):
+        # RowRange(start=-1, end=0) → ROWS BETWEEN 1 PRECEDING AND CURRENT ROW.
+        self._insert(pk=1, bounty=30_000_000)   # Luffy
+        self._insert(pk=2, bounty=320_000_000)  # Zoro
+        self._insert(pk=3, bounty=66_000_000)   # Nami
+
+        table = WindowTestModel._meta.db_table
+        qs = (
+            WindowTestModel.objects
+            .annotate(
+                sliding=Window(
+                    Sum("bounty"),
+                    order_by="id",
+                    frame=RowRange(start=-1, end=0),
+                )
+            )
+            .values_list("id", "sliding")
+            .order_by("id")
+        )
+        self.assertEqual(
+            str(qs.query),
+            f"SELECT `{table}`.`id` AS `id`, SUM(`{table}`.`bounty`) OVER"
+            f" (ORDER BY `{table}`.`id` ROWS BETWEEN 1 PRECEDING AND CURRENT ROW)"
+            f" AS `sliding` FROM `{table}` ORDER BY `{table}`.`id` ASC",
+        )
+
+        rows = list(qs)
+        self.assertEqual(rows[0][1], 30_000_000)            # only Luffy
+        self.assertEqual(rows[1][1], 350_000_000)           # Luffy + Zoro
+        self.assertEqual(rows[2][1], 386_000_000)           # Zoro + Nami
+
+    def test_bounded_value_range_raises_not_supported(self):
+        # ValueRange with a bounded offset must be rejected by Django before
+        # reaching YDB, because YDB does not support bounded RANGE frames.
+        self._insert(pk=1, bounty=30_000_000)
+
+        with self.assertRaises(NotSupportedError):
+            list(
+                WindowTestModel.objects.annotate(
+                    w=Window(
+                        Sum("bounty"),
+                        order_by="id",
+                        frame=ValueRange(start=-1, end=0),
+                    )
+                )
+            )

--- a/tests/backends/ydb/test_features.py
+++ b/tests/backends/ydb/test_features.py
@@ -280,11 +280,11 @@ class TestWindowFunctions(TransactionTestCase):
             .values_list("id", "running")
             .order_by("id")
         )
-        self.assertEqual(
+        # Assert only the OVER clause — the surrounding SELECT format varies
+        # across Django versions (e.g. 4.2 omits the AS alias on the id column).
+        self.assertIn(
+            f"SUM(`{table}`.`bounty`) OVER (ORDER BY `{table}`.`id`) AS `running`",
             str(qs.query),
-            f"SELECT `{table}`.`id` AS `id`, SUM(`{table}`.`bounty`) OVER"
-            f" (ORDER BY `{table}`.`id`) AS `running`"
-            f" FROM `{table}` ORDER BY `{table}`.`id` ASC",
         )
 
         rows = list(qs)
@@ -311,11 +311,13 @@ class TestWindowFunctions(TransactionTestCase):
             .values_list("id", "sliding")
             .order_by("id")
         )
-        self.assertEqual(
-            str(qs.query),
-            f"SELECT `{table}`.`id` AS `id`, SUM(`{table}`.`bounty`) OVER"
+        # Assert only the OVER clause — the surrounding SELECT format varies
+        # across Django versions (e.g. 4.2 omits the AS alias on the id column).
+        self.assertIn(
+            f"SUM(`{table}`.`bounty`) OVER"
             f" (ORDER BY `{table}`.`id` ROWS BETWEEN 1 PRECEDING AND CURRENT ROW)"
-            f" AS `sliding` FROM `{table}` ORDER BY `{table}`.`id` ASC",
+            f" AS `sliding`",
+            str(qs.query),
         )
 
         rows = list(qs)

--- a/tests/backends/ydb/test_features.py
+++ b/tests/backends/ydb/test_features.py
@@ -1,8 +1,8 @@
 """
-Tests for DatabaseFeatures: flag values and behavioral verification.
+Tests for DatabaseFeatures.
 
-Flag assertions document what YDB supports. Integration tests verify that
-the flags accurately reflect live database behavior.
+Flag values are consolidated into a single assertion test.
+Behavioral tests verify that YDB actually behaves as each flag claims.
 """
 from django.db import connection
 from django.db import models
@@ -15,197 +15,85 @@ from django.test import SimpleTestCase
 from django.test import TransactionTestCase
 
 # ---------------------------------------------------------------------------
-# Flag value assertions (no live DB required)
+# Flag value assertions — one test to catch accidental changes
 # ---------------------------------------------------------------------------
 
 
 class TestFeatureFlags(SimpleTestCase):
-    """Every explicit DatabaseFeatures override is asserted here."""
+    def test_all_flag_values(self):
+        f = connection.features
+        # group by
+        self.assertTrue(f.allows_group_by_selected_pks)
+        self.assertFalse(f.allows_group_by_select_index)
+        # update / delete
+        self.assertFalse(f.update_can_self_select)
+        self.assertFalse(f.delete_can_self_reference_subquery)
+        # null / string semantics
+        self.assertFalse(f.interprets_empty_strings_as_nulls)
+        self.assertTrue(f.ignores_table_name_case)
+        # unique / nullable constraints
+        self.assertFalse(f.supports_nullable_unique_constraints)
+        self.assertFalse(f.supports_partially_nullable_unique_constraints)
+        self.assertFalse(f.allows_multiple_constraints_on_same_fields)
+        # bulk insert
+        self.assertFalse(f.can_return_rows_from_bulk_insert)
+        self.assertFalse(f.supports_ignore_conflicts)
+        # transactions / savepoints
+        self.assertTrue(f.supports_transactions)
+        self.assertFalse(f.uses_savepoints)
+        self.assertFalse(f.supports_forward_references)
+        # native types
+        self.assertTrue(f.has_native_uuid_field)
+        self.assertTrue(f.has_native_duration_field)
+        self.assertTrue(f.has_native_json_field)
+        self.assertFalse(f.has_json_object_function)
+        self.assertTrue(f.supports_temporal_subtraction)
+        self.assertTrue(f.json_key_contains_list_matching_requires_list)
+        # regex / timezone
+        self.assertFalse(f.supports_regex_backreferencing)
+        self.assertFalse(f.has_zoneinfo_database)
+        # ordering
+        self.assertFalse(f.supports_order_by_nulls_modifier)
+        # auto pk
+        self.assertFalse(f.allows_auto_pk_0)
+        self.assertFalse(f.supports_sequence_reset)
+        # introspection
+        self.assertFalse(f.can_introspect_default)
+        self.assertFalse(f.can_introspect_foreign_keys)
+        self.assertFalse(f.can_introspect_check_constraints)
+        self.assertFalse(f.can_introspect_json_field)
+        self.assertFalse(f.supports_index_column_ordering)
+        # schema / DDL
+        self.assertTrue(f.schema_editor_uses_clientside_param_binding)
+        self.assertFalse(f.supports_foreign_keys)
+        self.assertFalse(f.can_create_inline_fk)
+        self.assertTrue(f.can_rename_index)
+        self.assertFalse(f.indexes_foreign_keys)
+        self.assertFalse(f.supports_column_check_constraints)
+        self.assertFalse(f.supports_table_check_constraints)
+        self.assertFalse(f.supports_expression_defaults)
+        self.assertFalse(f.supports_default_keyword_in_insert)
+        self.assertFalse(f.supports_default_keyword_in_bulk_insert)
+        # select variants
+        self.assertFalse(f.supports_select_for_update_with_limit)
+        self.assertFalse(f.supports_select_intersection)
+        self.assertFalse(f.supports_select_difference)
+        self.assertFalse(f.supports_parentheses_in_compound)
+        # window functions
+        self.assertTrue(f.supports_over_clause)
+        self.assertTrue(f.only_supports_unbounded_with_preceding_and_following)
+        # indexes
+        self.assertFalse(f.supports_partial_indexes)
+        self.assertFalse(f.supports_functions_in_partial_indexes)
+        self.assertTrue(f.supports_covering_indexes)
+        self.assertFalse(f.supports_expression_indexes)
+        # collation
+        self.assertFalse(f.supports_collation_on_charfield)
+        self.assertFalse(f.supports_collation_on_textfield)
+        self.assertFalse(f.supports_non_deterministic_collations)
 
-    # --- GROUP BY ---
-    def test_allows_group_by_selected_pks(self):
-        self.assertTrue(connection.features.allows_group_by_selected_pks)
+    # --- RANGE frame behavior: these test Django ops, not just flag values ---
 
-    def test_no_group_by_select_index(self):
-        # YDB rejects "GROUP BY 1" ordinal references.
-        self.assertFalse(connection.features.allows_group_by_select_index)
-
-    # --- UPDATE / DELETE self-reference ---
-    def test_no_update_self_select(self):
-        self.assertFalse(connection.features.update_can_self_select)
-
-    def test_no_delete_self_reference_subquery(self):
-        self.assertFalse(connection.features.delete_can_self_reference_subquery)
-
-    # --- NULL / string semantics ---
-    def test_does_not_interpret_empty_strings_as_nulls(self):
-        self.assertFalse(connection.features.interprets_empty_strings_as_nulls)
-
-    def test_ignores_table_name_case(self):
-        self.assertTrue(connection.features.ignores_table_name_case)
-
-    # --- Unique / nullable constraints ---
-    def test_no_nullable_unique_constraints(self):
-        self.assertFalse(connection.features.supports_nullable_unique_constraints)
-
-    def test_no_partially_nullable_unique_constraints(self):
-        self.assertFalse(
-            connection.features.supports_partially_nullable_unique_constraints
-        )
-
-    # --- Bulk insert ---
-    def test_no_bulk_insert_return_rows(self):
-        self.assertFalse(connection.features.can_return_rows_from_bulk_insert)
-
-    # --- Transactions / savepoints ---
-    def test_transactions_supported(self):
-        self.assertTrue(connection.features.supports_transactions)
-
-    def test_no_savepoints(self):
-        self.assertFalse(connection.features.uses_savepoints)
-
-    # --- References ---
-    def test_no_forward_references(self):
-        self.assertFalse(connection.features.supports_forward_references)
-
-    # --- Native types ---
-    def test_native_uuid_field(self):
-        self.assertTrue(connection.features.has_native_uuid_field)
-
-    def test_native_duration_field(self):
-        self.assertTrue(connection.features.has_native_duration_field)
-
-    def test_temporal_subtraction_supported(self):
-        self.assertTrue(connection.features.supports_temporal_subtraction)
-
-    # --- Regex ---
-    def test_no_regex_backreferencing(self):
-        self.assertFalse(connection.features.supports_regex_backreferencing)
-
-    # --- Timezone data ---
-    def test_no_zoneinfo_database(self):
-        self.assertFalse(connection.features.has_zoneinfo_database)
-
-    # --- ORDER BY ---
-    def test_no_order_by_nulls_modifier(self):
-        self.assertFalse(connection.features.supports_order_by_nulls_modifier)
-
-    # --- Auto PK ---
-    def test_no_auto_pk_0(self):
-        self.assertFalse(connection.features.allows_auto_pk_0)
-
-    def test_no_sequence_reset(self):
-        self.assertFalse(connection.features.supports_sequence_reset)
-
-    # --- Introspection ---
-    def test_no_introspect_default(self):
-        self.assertFalse(connection.features.can_introspect_default)
-
-    def test_no_introspect_foreign_keys(self):
-        self.assertFalse(connection.features.can_introspect_foreign_keys)
-
-    def test_no_introspect_check_constraints(self):
-        self.assertFalse(connection.features.can_introspect_check_constraints)
-
-    def test_no_introspect_json_field(self):
-        self.assertFalse(connection.features.can_introspect_json_field)
-
-    # --- Schema / DDL ---
-    def test_schema_editor_clientside_param_binding(self):
-        self.assertTrue(connection.features.schema_editor_uses_clientside_param_binding)
-
-    def test_no_foreign_keys(self):
-        self.assertFalse(connection.features.supports_foreign_keys)
-
-    def test_no_inline_fk(self):
-        self.assertFalse(connection.features.can_create_inline_fk)
-
-    def test_no_auto_index_foreign_keys(self):
-        self.assertFalse(connection.features.indexes_foreign_keys)
-
-    def test_no_column_check_constraints(self):
-        self.assertFalse(connection.features.supports_column_check_constraints)
-
-    def test_no_table_check_constraints(self):
-        self.assertFalse(connection.features.supports_table_check_constraints)
-
-    def test_no_expression_defaults(self):
-        self.assertFalse(connection.features.supports_expression_defaults)
-
-    def test_no_default_keyword_in_insert(self):
-        self.assertFalse(connection.features.supports_default_keyword_in_insert)
-
-    def test_no_default_keyword_in_bulk_insert(self):
-        self.assertFalse(connection.features.supports_default_keyword_in_bulk_insert)
-
-    # --- SELECT FOR UPDATE ---
-    def test_no_select_for_update_with_limit(self):
-        self.assertFalse(connection.features.supports_select_for_update_with_limit)
-
-    # --- Compound queries ---
-    def test_no_select_intersection(self):
-        self.assertFalse(connection.features.supports_select_intersection)
-
-    def test_no_select_difference(self):
-        self.assertFalse(connection.features.supports_select_difference)
-
-    def test_no_parentheses_in_compound(self):
-        self.assertFalse(connection.features.supports_parentheses_in_compound)
-
-    # --- Window functions ---
-    def test_over_clause_supported(self):
-        self.assertTrue(connection.features.supports_over_clause)
-
-    def test_only_unbounded_range_frames(self):
-        # YDB RANGE frames only work with UNBOUNDED PRECEDING/FOLLOWING.
-        # Bounded RANGE (e.g. RANGE BETWEEN 1 PRECEDING AND CURRENT ROW) fails.
-        self.assertTrue(
-            connection.features.only_supports_unbounded_with_preceding_and_following
-        )
-
-    # --- Conflicts ---
-    def test_no_ignore_conflicts(self):
-        self.assertFalse(connection.features.supports_ignore_conflicts)
-
-    # --- Indexes ---
-    def test_no_partial_indexes(self):
-        self.assertFalse(connection.features.supports_partial_indexes)
-
-    def test_no_functions_in_partial_indexes(self):
-        self.assertFalse(connection.features.supports_functions_in_partial_indexes)
-
-    def test_covering_indexes_supported(self):
-        self.assertTrue(connection.features.supports_covering_indexes)
-
-    def test_no_expression_indexes(self):
-        self.assertFalse(connection.features.supports_expression_indexes)
-
-    def test_no_multiple_constraints_same_fields(self):
-        self.assertFalse(connection.features.allows_multiple_constraints_on_same_fields)
-
-    # --- JSON ---
-    def test_native_json_field(self):
-        self.assertTrue(connection.features.has_native_json_field)
-
-    def test_json_key_contains_list_matching_requires_list(self):
-        self.assertTrue(
-            connection.features.json_key_contains_list_matching_requires_list
-        )
-
-    def test_no_json_object_function(self):
-        self.assertFalse(connection.features.has_json_object_function)
-
-    # --- Collation ---
-    def test_no_collation_on_charfield(self):
-        self.assertFalse(connection.features.supports_collation_on_charfield)
-
-    def test_no_collation_on_textfield(self):
-        self.assertFalse(connection.features.supports_collation_on_textfield)
-
-    def test_no_non_deterministic_collations(self):
-        self.assertFalse(connection.features.supports_non_deterministic_collations)
-
-    # --- Bounded RANGE frame raises NotSupportedError at Django level ---
     def test_bounded_range_frame_raises_not_supported(self):
         with self.assertRaises(NotSupportedError):
             connection.ops.window_frame_range_start_end(start=-1, end=0)
@@ -220,10 +108,122 @@ class TestFeatureFlags(SimpleTestCase):
         self.assertEqual(end, "CURRENT ROW")
 
     def test_bounded_rows_frame_is_allowed(self):
-        # ROWS frames are fine with bounded offsets.
         start, end = connection.ops.window_frame_rows_start_end(start=-1, end=0)
         self.assertEqual(start, "1 PRECEDING")
         self.assertEqual(end, "CURRENT ROW")
+
+
+# ---------------------------------------------------------------------------
+# Shared model for behavioral integration tests
+# ---------------------------------------------------------------------------
+
+
+class BehaviorTestModel(models.Model):
+    id = models.IntegerField(primary_key=True)
+    bounty = models.IntegerField()
+    name = models.CharField(max_length=200, null=True)  # noqa: DJ001
+
+    class Meta:
+        app_label = "backends"
+        db_table = "ydb_feat_behavior"
+        managed = False
+
+    def __str__(self):
+        return str(self.id)
+
+
+class BehaviorTestMixin:
+    def setUp(self):
+        try:
+            with connection.schema_editor() as ed:
+                ed.delete_model(BehaviorTestModel)
+        except Exception:  # noqa: BLE001
+            pass
+        with connection.schema_editor() as ed:
+            ed.create_model(BehaviorTestModel)
+
+    def tearDown(self):
+        try:
+            with connection.schema_editor() as ed:
+                ed.delete_model(BehaviorTestModel)
+        except Exception:  # noqa: BLE001
+            pass
+        super().tearDown()
+
+
+# ---------------------------------------------------------------------------
+# Behavioral: operations that must raise NotSupportedError
+# ---------------------------------------------------------------------------
+
+
+class TestUnsupportedOperations(BehaviorTestMixin, TransactionTestCase):
+    """
+    Verify that flags set to False actually cause NotSupportedError when the
+    corresponding operation is attempted, not just that the flag value is False.
+    """
+
+    databases = {"default"}
+
+    def test_intersection_raises_not_supported(self):
+        qs = BehaviorTestModel.objects.all()
+        with self.assertRaises(NotSupportedError):
+            list(qs.intersection(qs))
+
+    def test_difference_raises_not_supported(self):
+        qs = BehaviorTestModel.objects.all()
+        with self.assertRaises(NotSupportedError):
+            list(qs.difference(qs))
+
+    def test_ignore_conflicts_raises_not_supported(self):
+        with self.assertRaises(NotSupportedError):
+            BehaviorTestModel.objects.bulk_create(
+                [BehaviorTestModel(id=1, bounty=0)],
+                ignore_conflicts=True,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Behavioral: operations that must succeed
+# ---------------------------------------------------------------------------
+
+
+class TestSupportedBehavior(BehaviorTestMixin, TransactionTestCase):
+    """
+    Verify that flags set to True reflect actual YDB behavior.
+    """
+
+    databases = {"default"}
+
+    def test_empty_string_is_not_null(self):
+        # interprets_empty_strings_as_nulls = False:
+        # storing '' must not become NULL.
+        BehaviorTestModel.objects.create(id=1, bounty=0, name="")
+        obj = BehaviorTestModel.objects.get(id=1)
+        self.assertEqual(obj.name, "")
+        self.assertFalse(
+            BehaviorTestModel.objects.filter(id=1, name__isnull=True).exists()
+        )
+
+    def test_transactions_commit_data(self):
+        # supports_transactions = True: data written inside atomic() is visible
+        # after the block closes.
+        from django.db import transaction
+
+        with transaction.atomic():
+            BehaviorTestModel.objects.create(id=1, bounty=1_500_000_000)  # Whitebeard
+
+        self.assertTrue(BehaviorTestModel.objects.filter(id=1).exists())
+
+    def test_transactions_rollback_on_exception(self):
+        # supports_transactions = True: data written inside a rolled-back
+        # atomic() must not be visible afterwards.
+        from django.db import transaction
+
+        with self.assertRaises(ValueError), transaction.atomic():
+            BehaviorTestModel.objects.create(id=2, bounty=1_000_000_000)  # Roger
+            raise ValueError("rollback")
+
+        self.assertFalse(BehaviorTestModel.objects.filter(id=2).exists())
 
 
 # ---------------------------------------------------------------------------
@@ -231,62 +231,33 @@ class TestFeatureFlags(SimpleTestCase):
 # ---------------------------------------------------------------------------
 
 
-class WindowTestModel(models.Model):
-    id = models.IntegerField(primary_key=True)
-    bounty = models.IntegerField()
-
-    class Meta:
-        app_label = "backends"
-        db_table = "ydb_feat_window"
-        managed = False
-
-    def __str__(self):
-        return str(self.id)
+WindowTestModel = BehaviorTestModel
 
 
-class TestWindowFunctions(TransactionTestCase):
+class TestWindowFunctions(BehaviorTestMixin, TransactionTestCase):
     databases = {"default"}
 
-    def setUp(self):
-        try:
-            with connection.schema_editor() as ed:
-                ed.delete_model(WindowTestModel)
-        except Exception:  # noqa: BLE001
-            pass
-        with connection.schema_editor() as ed:
-            ed.create_model(WindowTestModel)
-
-    def tearDown(self):
-        try:
-            with connection.schema_editor() as ed:
-                ed.delete_model(WindowTestModel)
-        except Exception:  # noqa: BLE001
-            pass
-        super().tearDown()
-
     def _insert(self, pk, bounty):
-        WindowTestModel.objects.create(id=pk, bounty=bounty)
+        BehaviorTestModel.objects.create(id=pk, bounty=bounty)
 
     def test_unbounded_rows_frame_cumulative_sum(self):
-        # Default: no explicit frame → OVER (ORDER BY id).
         self._insert(pk=1, bounty=30_000_000)   # Luffy
         self._insert(pk=2, bounty=320_000_000)  # Zoro
         self._insert(pk=3, bounty=66_000_000)   # Nami
 
-        table = WindowTestModel._meta.db_table
+        table = BehaviorTestModel._meta.db_table
         qs = (
-            WindowTestModel.objects
+            BehaviorTestModel.objects
             .annotate(running=Window(Sum("bounty"), order_by="id"))
             .values_list("id", "running")
             .order_by("id")
         )
         # Assert only the OVER clause — the surrounding SELECT format varies
-        # across Django versions (e.g. 4.2 omits the AS alias on the id column).
+        # across Django versions (4.2 omits AS alias on the pk column).
         self.assertIn(
             f"SUM(`{table}`.`bounty`) OVER (ORDER BY `{table}`.`id`) AS `running`",
             str(qs.query),
         )
-
         rows = list(qs)
         self.assertEqual(rows[0][1], 30_000_000)
         self.assertEqual(rows[1][1], 350_000_000)
@@ -298,9 +269,9 @@ class TestWindowFunctions(TransactionTestCase):
         self._insert(pk=2, bounty=320_000_000)  # Zoro
         self._insert(pk=3, bounty=66_000_000)   # Nami
 
-        table = WindowTestModel._meta.db_table
+        table = BehaviorTestModel._meta.db_table
         qs = (
-            WindowTestModel.objects
+            BehaviorTestModel.objects
             .annotate(
                 sliding=Window(
                     Sum("bounty"),
@@ -311,28 +282,24 @@ class TestWindowFunctions(TransactionTestCase):
             .values_list("id", "sliding")
             .order_by("id")
         )
-        # Assert only the OVER clause — the surrounding SELECT format varies
-        # across Django versions (e.g. 4.2 omits the AS alias on the id column).
         self.assertIn(
             f"SUM(`{table}`.`bounty`) OVER"
             f" (ORDER BY `{table}`.`id` ROWS BETWEEN 1 PRECEDING AND CURRENT ROW)"
             f" AS `sliding`",
             str(qs.query),
         )
-
         rows = list(qs)
         self.assertEqual(rows[0][1], 30_000_000)            # only Luffy
         self.assertEqual(rows[1][1], 350_000_000)           # Luffy + Zoro
         self.assertEqual(rows[2][1], 386_000_000)           # Zoro + Nami
 
     def test_bounded_value_range_raises_not_supported(self):
-        # ValueRange with a bounded offset must be rejected by Django before
-        # reaching YDB, because YDB does not support bounded RANGE frames.
+        # ValueRange with bounded offset must be rejected before reaching YDB.
         self._insert(pk=1, bounty=30_000_000)
 
         with self.assertRaises(NotSupportedError):
             list(
-                WindowTestModel.objects.annotate(
+                BehaviorTestModel.objects.annotate(
                     w=Window(
                         Sum("bounty"),
                         order_by="id",

--- a/tests/backends/ydb/test_indexes.py
+++ b/tests/backends/ydb/test_indexes.py
@@ -168,6 +168,9 @@ class TestIndexIntegration(TransactionTestCase):
         IndexTestBook.objects.create(**kwargs)
 
     def _select_view(self, index_name, where_col, where_val, select_cols="*"):
+        # Raw f-string interpolation is intentional: the YDB VIEW hint syntax
+        # (`TABLE VIEW INDEX`) has no ORM equivalent, and all values here are
+        # controlled test literals, never user input.
         table = IndexTestBook._meta.db_table
         sql = (
             f"SELECT {select_cols} FROM `{table}` VIEW `{index_name}`"

--- a/tests/backends/ydb/test_indexes.py
+++ b/tests/backends/ydb/test_indexes.py
@@ -1,0 +1,294 @@
+from django.db import connection
+from django.db import models
+from django.db.models import Index
+from django.test import SimpleTestCase
+from django.test import TransactionTestCase
+
+
+class IndexTestBook(models.Model):
+    """Dedicated model for index tests. Table lifecycle managed by setUp/tearDown."""
+
+    id = models.IntegerField(primary_key=True)
+    title = models.CharField(max_length=256)
+    author = models.CharField(max_length=256)
+    year = models.IntegerField(null=True)
+
+    class Meta:
+        app_label = "backends"
+        db_table = "ydb_idx_test_book"
+        managed = False
+
+    def __str__(self):
+        return f"{self.id}: {self.title}"
+
+
+# ---------------------------------------------------------------------------
+# Feature flag tests
+# ---------------------------------------------------------------------------
+
+
+class TestIndexFeatureFlags(SimpleTestCase):
+    def test_covering_indexes_supported(self):
+        self.assertTrue(connection.features.supports_covering_indexes)
+
+    def test_expression_indexes_not_supported(self):
+        self.assertFalse(connection.features.supports_expression_indexes)
+
+    def test_partial_indexes_not_supported(self):
+        self.assertFalse(connection.features.supports_partial_indexes)
+
+    def test_rename_index_supported(self):
+        self.assertTrue(connection.features.can_rename_index)
+
+    def test_unique_index_sql_disabled(self):
+        # YDB ALTER TABLE ADD INDEX has no UNIQUE variant.
+        self.assertIsNone(connection.SchemaEditorClass.sql_create_unique_index)
+
+
+# ---------------------------------------------------------------------------
+# SQL generation tests (collect_sql=True — no live DB required)
+# ---------------------------------------------------------------------------
+
+_TABLE = "`ydb_idx_test_book`"
+
+
+class TestIndexSQLGeneration(SimpleTestCase):
+    def _sql(self, fn):
+        with connection.schema_editor(collect_sql=True) as editor:
+            fn(editor)
+        self.assertEqual(len(editor.collected_sql), 1)
+        return editor.collected_sql[0]
+
+    # --- CREATE INDEX ---
+
+    def test_regular_index(self):
+        idx = Index(fields=["title"], name="t_title_idx")
+        self.assertEqual(
+            self._sql(lambda ed: ed.add_index(IndexTestBook, idx)),
+            f"ALTER TABLE {_TABLE} ADD INDEX `t_title_idx` GLOBAL ON (`title`);",
+        )
+
+    def test_composite_index(self):
+        idx = Index(fields=["author", "year"], name="t_comp_idx")
+        self.assertEqual(
+            self._sql(lambda ed: ed.add_index(IndexTestBook, idx)),
+            f"ALTER TABLE {_TABLE} ADD INDEX `t_comp_idx`"
+            f" GLOBAL ON (`author`, `year`);",
+        )
+
+    def test_covering_index_single_cover_column(self):
+        idx = Index(fields=["title"], include=["author"], name="t_cover_idx")
+        self.assertEqual(
+            self._sql(lambda ed: ed.add_index(IndexTestBook, idx)),
+            f"ALTER TABLE {_TABLE} ADD INDEX `t_cover_idx`"
+            f" GLOBAL ON (`title`) COVER (`author`);",
+        )
+
+    def test_covering_index_multiple_cover_columns(self):
+        idx = Index(
+            fields=["title"], include=["author", "year"], name="t_cover2_idx"
+        )
+        self.assertEqual(
+            self._sql(lambda ed: ed.add_index(IndexTestBook, idx)),
+            f"ALTER TABLE {_TABLE} ADD INDEX `t_cover2_idx`"
+            f" GLOBAL ON (`title`) COVER (`author`, `year`);",
+        )
+
+    # --- RENAME INDEX ---
+
+    def test_rename_index(self):
+        old = Index(fields=["title"], name="t_old_idx")
+        new = Index(fields=["title"], name="t_new_idx")
+        self.assertEqual(
+            self._sql(lambda ed: ed.rename_index(IndexTestBook, old, new)),
+            f"ALTER TABLE {_TABLE} RENAME INDEX `t_old_idx` TO `t_new_idx`;",
+        )
+
+    # --- DROP INDEX ---
+
+    def test_delete_index(self):
+        idx = Index(fields=["title"], name="t_drop_idx")
+        self.assertEqual(
+            self._sql(lambda ed: ed.remove_index(IndexTestBook, idx)),
+            f"ALTER TABLE {_TABLE} DROP INDEX `t_drop_idx`;",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Integration tests (require live YDB)
+# ---------------------------------------------------------------------------
+
+
+class TestIndexIntegration(TransactionTestCase):
+    databases = {"default"}
+
+    # -- table lifecycle --
+
+    def setUp(self):
+        self._ensure_clean_table()
+
+    def tearDown(self):
+        self._drop_table()
+        super().tearDown()
+
+    def _ensure_clean_table(self):
+        try:
+            with connection.schema_editor() as editor:
+                editor.delete_model(IndexTestBook)
+        except Exception:  # noqa: BLE001
+            pass
+        with connection.schema_editor() as editor:
+            editor.create_model(IndexTestBook)
+
+    def _drop_table(self):
+        try:
+            with connection.schema_editor() as editor:
+                editor.delete_model(IndexTestBook)
+        except Exception:  # noqa: BLE001
+            pass
+
+    # -- helpers --
+
+    def _add_index(self, index):
+        with connection.schema_editor() as editor:
+            editor.add_index(IndexTestBook, index)
+
+    def _remove_index(self, index):
+        with connection.schema_editor() as editor:
+            editor.remove_index(IndexTestBook, index)
+
+    def _get_indexes(self):
+        with connection.cursor() as cursor:
+            constraints = connection.introspection.get_constraints(
+                cursor, IndexTestBook._meta.db_table
+            )
+        return {k: v for k, v in constraints.items() if v.get("index")}
+
+    def _insert(self, **kwargs):
+        IndexTestBook.objects.create(**kwargs)
+
+    def _select_view(self, index_name, where_col, where_val, select_cols="*"):
+        table = IndexTestBook._meta.db_table
+        sql = (
+            f"SELECT {select_cols} FROM `{table}` VIEW `{index_name}`"
+            f" WHERE `{where_col}` = '{where_val}';"
+        )
+        with connection.cursor() as cursor:
+            cursor.execute(sql)
+            return cursor.fetchall()
+
+    # -- CREATE INDEX --
+
+    def test_create_regular_index_appears_in_introspection(self):
+        idx = Index(fields=["title"], name="i_title_idx")
+        self._add_index(idx)
+        self.assertIn("i_title_idx", self._get_indexes())
+
+    def test_create_composite_index_appears_in_introspection(self):
+        idx = Index(fields=["author", "year"], name="i_comp_idx")
+        self._add_index(idx)
+        self.assertIn("i_comp_idx", self._get_indexes())
+
+    def test_create_covering_index_appears_in_introspection(self):
+        idx = Index(fields=["title"], include=["author"], name="i_cover_idx")
+        self._add_index(idx)
+        self.assertIn("i_cover_idx", self._get_indexes())
+
+    def test_create_multiple_indexes_all_appear(self):
+        self._add_index(Index(fields=["title"], name="i_multi_title"))
+        self._add_index(Index(fields=["author"], name="i_multi_author"))
+        indexes = self._get_indexes()
+        self.assertIn("i_multi_title", indexes)
+        self.assertIn("i_multi_author", indexes)
+
+    # -- DELETE INDEX --
+
+    def test_delete_index_removes_from_introspection(self):
+        idx = Index(fields=["title"], name="i_del_idx")
+        self._add_index(idx)
+        self.assertIn("i_del_idx", self._get_indexes())
+        self._remove_index(idx)
+        self.assertNotIn("i_del_idx", self._get_indexes())
+
+    def test_delete_one_index_leaves_others(self):
+        idx1 = Index(fields=["title"], name="i_keep_idx")
+        idx2 = Index(fields=["author"], name="i_gone_idx")
+        self._add_index(idx1)
+        self._add_index(idx2)
+        self._remove_index(idx2)
+        indexes = self._get_indexes()
+        self.assertIn("i_keep_idx", indexes)
+        self.assertNotIn("i_gone_idx", indexes)
+
+    # -- RENAME INDEX --
+
+    def test_rename_index_old_name_gone_new_name_present(self):
+        old = Index(fields=["title"], name="i_rn_old")
+        new = Index(fields=["title"], name="i_rn_new")
+        self._add_index(old)
+        with connection.schema_editor() as editor:
+            editor.rename_index(IndexTestBook, old, new)
+        indexes = self._get_indexes()
+        self.assertNotIn("i_rn_old", indexes)
+        self.assertIn("i_rn_new", indexes)
+
+    # -- SELECT VIEW (index hint) --
+
+    def test_regular_index_select_view_returns_correct_rows(self):
+        idx = Index(fields=["title"], name="i_view_idx")
+        self._add_index(idx)
+        self._insert(id=1, title="Gomu Gomu no Mi", author="Luffy", year=1997)
+        self._insert(id=2, title="Thousand Sunny", author="Franky", year=2005)
+
+        rows = self._select_view("i_view_idx", "title", "Gomu Gomu no Mi", "`title`")
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0][0], "Gomu Gomu no Mi")
+
+    def test_regular_index_select_view_empty_for_missing_value(self):
+        idx = Index(fields=["title"], name="i_empty_idx")
+        self._add_index(idx)
+        self._insert(id=1, title="One Piece", author="Nami", year=1997)
+
+        rows = self._select_view("i_empty_idx", "title", "Poseidon", "`title`")
+        self.assertEqual(rows, [])
+
+    def test_covering_index_select_view_returns_cover_columns(self):
+        idx = Index(fields=["title"], include=["author"], name="i_cov_view_idx")
+        self._add_index(idx)
+        self._insert(id=1, title="All Blue", author="Sanji", year=1997)
+
+        rows = self._select_view(
+            "i_cov_view_idx", "title", "All Blue", "`title`, `author`"
+        )
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0][0], "All Blue")
+        self.assertEqual(rows[0][1], "Sanji")
+
+    def test_covering_index_select_view_multiple_cover_columns(self):
+        idx = Index(
+            fields=["title"], include=["author", "year"], name="i_cov2_view_idx"
+        )
+        self._add_index(idx)
+        self._insert(id=1, title="Will of D", author="Robin", year=1997)
+
+        rows = self._select_view(
+            "i_cov2_view_idx",
+            "title",
+            "Will of D",
+            "`title`, `author`, `year`",
+        )
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0][1], "Robin")
+        self.assertEqual(rows[0][2], 1997)
+
+    def test_composite_index_select_view_by_first_column(self):
+        idx = Index(fields=["author", "year"], name="i_comp_view_idx")
+        self._add_index(idx)
+        self._insert(id=1, title="Straw Hat Pirates", author="Ace", year=1997)
+        self._insert(id=2, title="Whitebeard Pirates", author="Sabo", year=1997)
+
+        rows = self._select_view(
+            "i_comp_view_idx", "author", "Ace", "`author`"
+        )
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0][0], "Ace")

--- a/ydb_backend/backend/base.py
+++ b/ydb_backend/backend/base.py
@@ -241,6 +241,12 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         """
         Backend-specific implementation to enable or disable autocommit.
         """
+        conn = self.connection
+        if autocommit:
+            conn.interactive_transaction = False
+        else:
+            conn.interactive_transaction = True
+            conn.begin()
 
     def is_usable(self):
         """

--- a/ydb_backend/backend/features.py
+++ b/ydb_backend/backend/features.py
@@ -161,7 +161,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_covering_indexes = True
 
     # Does the backend support indexes on expressions?
-    supports_expression_indexes = True
+    supports_expression_indexes = False
 
     # Does the database allow more than one constraint or index on the same
     # field(s)?

--- a/ydb_backend/backend/features.py
+++ b/ydb_backend/backend/features.py
@@ -114,8 +114,8 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_column_check_constraints = False
     supports_table_check_constraints = False
 
-    # Does the backend support introspection of CHECK constraints?
-    can_introspect_check_constraints = True
+    # YDB does not support CHECK constraints, so there is nothing to introspect.
+    can_introspect_check_constraints = False
 
     # Does the backend support functions in defaults?
     supports_expression_defaults = False
@@ -137,6 +137,8 @@ class DatabaseFeatures(BaseDatabaseFeatures):
 
     # Does the backend support window expressions (expression OVER (...))?
     supports_over_clause = True
+    # YDB supports ROWS BETWEEN N PRECEDING/FOLLOWING, but RANGE with bounded
+    # offsets (RANGE BETWEEN N PRECEDING AND ...) is not supported.
     only_supports_unbounded_with_preceding_and_following = True
 
     # SQL to create a table with a composite primary key for use by the Django

--- a/ydb_backend/backend/schema.py
+++ b/ydb_backend/backend/schema.py
@@ -7,6 +7,7 @@ from enum import Enum
 from uuid import UUID
 
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+from django.db.backends.ddl_references import Columns
 from django.db.backends.ddl_references import Statement
 from django.db.transaction import TransactionManagementError
 
@@ -94,12 +95,10 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         "ALTER TABLE %(table)s RENAME INDEX %(old_name)s TO %(new_name)s;"
     )
     sql_create_index = (
-        "ALTER TABLE %(table)s ADD INDEX %(name)s GLOBAL ON (%(columns)s);"
+        "ALTER TABLE %(table)s ADD INDEX %(name)s GLOBAL ON (%(columns)s)%(include)s;"
     )
-    # TODO: how to use?
-    sql_create_unique_index = (
-        "ALTER TABLE %(table)s ADD INDEX %(name)s GLOBAL UNIQUE ON (%(columns)s);"
-    )
+    # YDB has no GLOBAL UNIQUE variant in ALTER TABLE ADD INDEX syntax.
+    sql_create_unique_index = None
     sql_rename_table = "ALTER TABLE %(old_table)s RENAME TO %(new_table)s;"
     sql_create_column = "ALTER TABLE %(table)s ADD COLUMN %(column)s %(definition)s;"
     sql_alter_column = "ALTER TABLE %(table)s %(changes)s;"
@@ -132,6 +131,14 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
     sql_alter_column_default = None
     sql_alter_column_no_default = None
     sql_alter_column_no_default_null = None
+
+    def _index_include_sql(self, model, columns):
+        if not columns or not self.connection.features.supports_covering_indexes:
+            return ""
+        return Statement(
+            " COVER (%(columns)s)",
+            columns=Columns(model._meta.db_table, columns, self.quote_name),
+        )
 
     def prepare_default(self, value):
         """

--- a/ydb_backend/models/sql/compiler.py
+++ b/ydb_backend/models/sql/compiler.py
@@ -87,34 +87,46 @@ def _replace_placeholders(sql):
     return sql, placeholder_rows
 
 
+def _infer_ydb_type(value):
+    """Infer a YDB type from a Python value when no column name is available."""
+    if isinstance(value, bool):
+        return ydb.PrimitiveType.Bool
+    if isinstance(value, int):
+        return ydb.PrimitiveType.Int64
+    if isinstance(value, float):
+        return ydb.PrimitiveType.Double
+    if isinstance(value, str):
+        return ydb.PrimitiveType.Utf8
+    if isinstance(value, bytes):
+        return ydb.PrimitiveType.String
+    raise ValueError(f"Cannot infer YDB type for value {value!r} of type {type(value)}")
+
+
 def _generate_params_for_update(placeholder_rows, columns, field_types, params):
-    model_types = []
-
-    for column in columns:
-        if column in field_types:
-            model_types.append(field_types[column])
-
     modified_params = {}
 
-    for i in range(len(placeholder_rows)):
-        if str(model_types[i]) == "DateTimeField":
-            val = params[i]
+    for i, placeholder in enumerate(placeholder_rows):
+        column = columns[i] if i < len(columns) else None
+        field_type = field_types.get(column) if column is not None else None
+        val = params[i]
+
+        if field_type is None:
+            # Column unknown (e.g. Value() annotation in SELECT) — infer from value.
+            modified_params[placeholder] = (val, _infer_ydb_type(val))
+        elif field_type == "DateTimeField":
             if isinstance(val, int):
                 # val is an extract comparison (e.g. __month=1, __day=15) produced
                 # by DateTime::GetMonth / DateTime::GetDay / etc.  The column name
                 # heuristic in _extract_column_names points to the DateTimeField, but
                 # the placeholder holds an integer operand, not a timestamp.
-                modified_params[placeholder_rows[i]] = (val, ydb.PrimitiveType.Int32)
+                modified_params[placeholder] = (val, ydb.PrimitiveType.Int32)
             else:
-                modified_params[placeholder_rows[i]] = (
+                modified_params[placeholder] = (
                     int(val.timestamp()),
-                    _ydb_types[model_types[i]]
+                    _ydb_types[field_type],
                 )
         else:
-            modified_params[placeholder_rows[i]] = (
-                params[i],
-                _ydb_types[model_types[i]]
-            )
+            modified_params[placeholder] = (val, _ydb_types[field_type])
 
     return modified_params
 
@@ -451,7 +463,7 @@ class BaseSQLWriteCompiler(compiler.SQLInsertCompiler):
 
         with self.connection.cursor() as cursor:
             for sql, params in self.as_sql():
-                cursor.execute_scheme(sql, params)
+                cursor.execute(sql, params)
 
             if not returning_fields:
                 return []

--- a/ydb_backend/models/sql/compiler.py
+++ b/ydb_backend/models/sql/compiler.py
@@ -99,7 +99,8 @@ def _infer_ydb_type(value):
         return ydb.PrimitiveType.Utf8
     if isinstance(value, bytes):
         return ydb.PrimitiveType.String
-    raise ValueError(f"Cannot infer YDB type for value {value!r} of type {type(value)}")
+    msg = f"Cannot infer YDB type for value {value!r} of type {type(value)}"
+    raise ValueError(msg)
 
 
 def _generate_params_for_update(placeholder_rows, columns, field_types, params):

--- a/ydb_backend/models/sql/compiler.py
+++ b/ydb_backend/models/sql/compiler.py
@@ -1,4 +1,8 @@
 import re
+from datetime import date
+from datetime import datetime
+from decimal import Decimal
+from uuid import UUID
 
 import ydb
 from django.core.exceptions import EmptyResultSet
@@ -89,6 +93,8 @@ def _replace_placeholders(sql):
 
 def _infer_ydb_type(value):
     """Infer a YDB type from a Python value when no column name is available."""
+    if value is None:
+        return ydb.OptionalType(ydb.PrimitiveType.Utf8)
     if isinstance(value, bool):
         return ydb.PrimitiveType.Bool
     if isinstance(value, int):
@@ -99,6 +105,10 @@ def _infer_ydb_type(value):
         return ydb.PrimitiveType.Utf8
     if isinstance(value, bytes):
         return ydb.PrimitiveType.String
+    if isinstance(value, UUID):
+        return ydb.PrimitiveType.UUID
+    if isinstance(value, Decimal):
+        return ydb.DecimalType(22, 9)
     msg = f"Cannot infer YDB type for value {value!r} of type {type(value)}"
     raise ValueError(msg)
 
@@ -113,7 +123,15 @@ def _generate_params_for_update(placeholder_rows, columns, field_types, params):
 
         if field_type is None:
             # Column unknown (e.g. Value() annotation in SELECT) — infer from value.
-            modified_params[placeholder] = (val, _infer_ydb_type(val))
+            # datetime/date need the same timestamp conversion as DateTimeField.
+            if isinstance(val, datetime):
+                modified_params[placeholder] = (
+                    int(val.timestamp()), ydb.PrimitiveType.Datetime
+                )
+            elif isinstance(val, date):
+                modified_params[placeholder] = (val, ydb.PrimitiveType.Date)
+            else:
+                modified_params[placeholder] = (val, _infer_ydb_type(val))
         elif field_type == "DateTimeField":
             if isinstance(val, int):
                 # val is an extract comparison (e.g. __month=1, __day=15) produced


### PR DESCRIPTION
Closes #31.

## Summary

### Flag corrections
- `can_introspect_check_constraints = False` — YDB has no CHECK constraints so there is nothing to introspect (was incorrectly `True`).
- `sql_create_unique_index = None` — `GLOBAL UNIQUE` is not valid YDB syntax; no UNIQUE index variant exists.
- `supports_expression_indexes = False` — YDB `ALTER TABLE ADD INDEX` has no expression-based variant.

### Covering index implementation
- `sql_create_index` now includes `%(include)s` placeholder.
- `_index_include_sql` overridden to emit YDB's `COVER (...)` clause.

### Documented flags
- `only_supports_unbounded_with_preceding_and_following = True` — added comment clarifying this applies to RANGE frames only; bounded ROWS frames work fine in YDB.

### Bug fixes (discovered while writing behavioral tests)
- `_generate_params_for_update` crashed with `IndexError` on any SELECT that includes a `Value()` annotation (e.g. `.exists()`). Django 5.2 compiles `Value(1)` as `%s` in the SELECT clause with no preceding column name, making `model_types` shorter than `placeholder_rows`. Fixed by iterating `placeholder_rows` directly and falling back to `_infer_ydb_type()` when no column is known.
- `_set_autocommit()` was a no-op stub, so `transaction.atomic()` never actually started a YDB transaction and `rollback()` was silently ignored. Implemented: sets `interactive_transaction` on the dbapi connection and calls `begin()` when entering non-autocommit mode.
- `BaseSQLWriteCompiler.execute_sql` used `execute_scheme()` for INSERT/UPSERT, which bypasses the transaction context entirely. Switched to `execute()` so DML participates in active transactions.

### Tests

**`tests/backends/ydb/test_indexes.py`** — SQL generation tests (exact query strings) and live integration tests for all index operations: CREATE, DROP, RENAME, covering indexes, `SELECT VIEW` hints.

**`tests/backends/ydb/test_features.py`** — rewritten around two principles:

- *Flag assertions* (`TestFeatureFlags`): all explicit `DatabaseFeatures` overrides pinned in one method so accidental changes are immediately visible. Four unit tests verify the window-frame helper methods directly.
- *Behavioral tests*: three test classes verify that flags reflect actual YDB behavior, not just declared intent:
  - `TestUnsupportedOperations` — `intersection`, `difference`, `ignore_conflicts` each raise `NotSupportedError` as the flags promise.
  - `TestSupportedBehavior` — empty strings stay non-NULL; `atomic()` commits data durably; `atomic()` rolls back on exception.
  - `TestWindowFunctions` — cumulative SUM with unbounded ROWS, sliding SUM with 1-PRECEDING ROWS, bounded RANGE raises `NotSupportedError`; all verified at both the SQL-string level and with live query results.

**Flags not covered by behavioral tests** — `requires_compound_order_by_subquery = False` cannot be reached: compound queries raise `NotSupportedError` before this flag takes effect. Structural `False` flags (`supports_foreign_keys`, `supports_partial_indexes`, etc.) govern Django ORM/test-runner behaviour rather than YDB server responses, so behavioral coverage is not meaningful for them.

## Test commands

```
poetry run python tests/runtests.py backends -v 1
```

92 tests, all passing.