### PR TITLE
feat: accurate introspection and explicit schema-op boundary (#45, #35)

### DIFF
--- a/docs/MIGRATIONS.md
+++ b/docs/MIGRATIONS.md
@@ -4,35 +4,84 @@ Migrations
 YDB, as a distributed OLTP/OLAP system, has a number of architectural limitations that significantly affect the migration process. 
 Unlike traditional DBMS (PostgreSQL, MySQL), many YDB operations require a special approach or are not available at all.
 
+## How unsupported operations behave
+
+The schema editor never *silently* ignores an unsupported operation. Depending
+on how dangerous the operation is, it either fails fast or is skipped with a
+logged warning:
+
+- **Raises `NotSupportedError`** for changes that would leave the table and the
+  Django model out of sync and break queries: renaming a column, changing a
+  column type, and changing the primary key. The migration fails fast instead
+  of corrupting the schema.
+- **Skipped with a warning** for operations that YDB cannot honour but that
+  leave the table queryable: unique/check constraints, `unique_together`, and
+  nullability changes after table creation. These are logged (logger
+  `django_ydb_backend.ydb_backend.backend.schema`) and the migration proceeds.
+
+Because unenforceable operations are skipped rather than rejected,
+`python manage.py migrate` for the standard Django apps (`contenttypes`,
+`auth`, `admin`, `sessions`) runs to completion. **Uniqueness and check
+guarantees are not enforced by the database** and must be implemented in
+application logic.
+
 ## Limited ALTER TABLE
 
 **Supported:**
 - Add/remove columns (ADD COLUMN, DROP COLUMN).
 - Rename the TABLE.
+- Add/drop a secondary index for a field (`db_index`).
 
-**Not supported:**
-- Change the column type/name (ALTER COLUMN TYPE).
-- NULL/NOT NULL change after creating the table.
-- Bypass: It requires creating a new table with the required schema and copying the data.
+**Raises `NotSupportedError`:**
+- Change the column type (ALTER COLUMN TYPE).
+- Rename a column.
+- Change the primary key.
+- Workaround: create a new table with the required schema and copy the data.
+
+**Skipped with a warning:**
+- NULL/NOT NULL change after creating the table (the column keeps its original
+  nullability).
+- Default value changes are a no-op (defaults are applied by Django, not stored
+  in YDB).
 
 ## Uniqueness and Constraints
-**Not supported**:
-- UNIQUE constraints (even the sql_create_unique_index syntax in the code does not guarantee uniqueness).
-- Foreign keys (FOREIGN KEY).
+**Not enforced (skipped with a warning):**
+- UNIQUE constraints and `unique_together` (even the `sql_create_unique_index`
+  syntax does not guarantee uniqueness in YDB).
 - Verification restrictions (CHECK).
+
+**Not supported:**
+- Foreign keys (FOREIGN KEY) — no foreign-key constraints are created or
+  introspected.
 
 **Solution:** Data integrity control is assigned to the application logic.
 
 ## Indexes
 **Features:**
 - Indexes are created via ADD INDEX ... GLOBAL (as in the code example) or are set when creating table.
+- Secondary indexes are non-unique.
 
 ## Primary Keys
 **Strict requirements:**
 - PK must be explicitly specified when creating the table (PRIMARY KEY (%(primary_key)s)).
-- You cannot change the PK after creating the table.
+- You cannot change the PK after creating the table (raises `NotSupportedError`).
 
 ## Comments and metadata
 **Not supported:**
 - Comments on tables/columns (sql_alter_table_comment = None).
 - Stored procedures (sql_delete_procedure = None).
+
+## Introspection and `inspectdb`
+
+Introspection reflects what YDB actually exposes through `DESCRIBE`:
+
+- **Nullability** is accurate: a column reported as `Optional<T>` is nullable,
+  otherwise it is NOT NULL.
+- **Sequences** are reported only for an integer primary key (the shape Django
+  uses for auto fields); YDB does not expose `Serial` metadata directly.
+- **Indexes** are reported with their columns and ascending order; secondary
+  indexes are non-unique. Foreign keys and check constraints are never reported
+  because YDB does not enforce them.
+- **`inspectdb`** maps a YDB column type back to the closest Django field. The
+  mapping is lossy where several Django fields share one YDB type (for example
+  `Utf8` is reported as `TextField`, and `Double` as `FloatField`).

--- a/tests/backends/ydb/test_introspection.py
+++ b/tests/backends/ydb/test_introspection.py
@@ -7,22 +7,53 @@ from ydb_backend.backend.introspection import TableInfo
 class TestDatabaseIntrospection(TestCase):
     databases = {"default"}
 
-    def test_get_field_type(self):
+    def test_get_yql_type(self):
+        # Forward mapping (Django internal type -> YQL type) used to build
+        # DECLARE statements in the insert/upsert compilers.
         self.assertEqual(
-            connection.introspection.get_field_type("AutoField", ""),
+            connection.introspection.get_yql_type("AutoField"),
             "Int32",
         )
         self.assertEqual(
-            connection.introspection.get_field_type("PositiveIntegerField", ""),
+            connection.introspection.get_yql_type("PositiveIntegerField"),
             "Uint32",
         )
         self.assertEqual(
-            connection.introspection.get_field_type("NullBooleanField", ""),
+            connection.introspection.get_yql_type("NullBooleanField"),
             "optional<Bool>",
         )
         self.assertEqual(
-            connection.introspection.get_field_type("UUIDField", ""),
+            connection.introspection.get_yql_type("UUIDField"),
             "UUID",
+        )
+
+    def test_get_field_type_reverse(self):
+        # Reverse mapping (YDB type name -> Django field) used by introspection
+        # and inspectdb.
+        self.assertEqual(
+            connection.introspection.get_field_type("Int32", None),
+            "IntegerField",
+        )
+        self.assertEqual(
+            connection.introspection.get_field_type("Uint32", None),
+            "PositiveIntegerField",
+        )
+        self.assertEqual(
+            connection.introspection.get_field_type("Bool", None),
+            "BooleanField",
+        )
+        self.assertEqual(
+            connection.introspection.get_field_type("UUID", None),
+            "UUIDField",
+        )
+        self.assertEqual(
+            connection.introspection.get_field_type("Decimal", None),
+            "DecimalField",
+        )
+        # Unknown YDB types fall back to TextField so inspectdb keeps working.
+        self.assertEqual(
+            connection.introspection.get_field_type("Mystery", None),
+            "TextField",
         )
 
     def test_table_names(self):
@@ -39,7 +70,7 @@ class TestDatabaseIntrospection(TestCase):
                 internal_size=None,
                 precision=None,
                 scale=None,
-                null_ok=None,
+                null_ok=False,
                 default=None,
                 collation=None,
             ),
@@ -50,7 +81,7 @@ class TestDatabaseIntrospection(TestCase):
                 internal_size=None,
                 precision=None,
                 scale=None,
-                null_ok=None,
+                null_ok=False,
                 default=None,
                 collation=None,
             ),
@@ -61,18 +92,18 @@ class TestDatabaseIntrospection(TestCase):
                 internal_size=None,
                 precision=None,
                 scale=None,
-                null_ok=None,
+                null_ok=False,
                 default=None,
                 collation=None,
             ),
             FieldInfo(
                 name="is_man",
-                type_code="Bool?",
+                type_code="Bool",
                 display_size=None,
                 internal_size=None,
                 precision=None,
                 scale=None,
-                null_ok=None,
+                null_ok=True,
                 default=None,
                 collation=None,
             ),
@@ -83,7 +114,7 @@ class TestDatabaseIntrospection(TestCase):
                 internal_size=None,
                 precision=None,
                 scale=None,
-                null_ok=None,
+                null_ok=False,
                 default=None,
                 collation=None,
             ),
@@ -94,7 +125,7 @@ class TestDatabaseIntrospection(TestCase):
                 internal_size=None,
                 precision=None,
                 scale=None,
-                null_ok=None,
+                null_ok=False,
                 default=None,
                 collation=None,
             ),
@@ -118,13 +149,10 @@ class TestDatabaseIntrospection(TestCase):
         self.assertIn(backends_person, result)
 
     def test_get_sequences(self):
+        # Only the integer auto-increment primary key is reported as a
+        # sequence, using Django's {'table', 'column'} contract.
         expected_result = [
-            {"table_name": "backends_person", "column_name": "first_name"},
-            {"table_name": "backends_person", "column_name": "last_name"},
-            {"table_name": "backends_person", "column_name": "id"},
-            {"table_name": "backends_person", "column_name": "is_man"},
-            {"table_name": "backends_person", "column_name": "about"},
-            {"table_name": "backends_person", "column_name": "age"},
+            {"table": "backends_person", "column": "id"},
         ]
 
         with connection.cursor() as cursor:
@@ -133,6 +161,16 @@ class TestDatabaseIntrospection(TestCase):
             )
 
         self.assertEqual(result, expected_result)
+
+    def test_get_sequences_skips_non_integer_pk(self):
+        # compiler_product has a CharField primary key ("sku"), which is not an
+        # auto-increment sequence.
+        with connection.cursor() as cursor:
+            result = connection.introspection.get_sequences(
+                cursor, "compiler_product"
+            )
+
+        self.assertEqual(result, [])
 
     def test_get_constraints(self):
         # TODO: Try to use model with indexes
@@ -144,6 +182,7 @@ class TestDatabaseIntrospection(TestCase):
                 "foreign_key": None,
                 "check": False,
                 "index": True,
+                "orders": ["ASC"],
                 "type": None,
             }
         }
@@ -160,3 +199,29 @@ class TestDatabaseIntrospection(TestCase):
             )
 
         self.assertEqual(["id"], result)
+
+    def test_get_table_description_decimal_precision_scale(self):
+        with connection.cursor() as cursor:
+            result = connection.introspection.get_table_description(
+                cursor, "type_floatingpointmodel"
+            )
+
+        decimal_field = next(f for f in result if f.name == "decimal_field")
+        self.assertEqual(decimal_field.type_code, "Decimal")
+        self.assertEqual(decimal_field.precision, 22)
+        self.assertEqual(decimal_field.scale, 9)
+        self.assertFalse(decimal_field.null_ok)
+
+    def test_get_constraints_index_metadata(self):
+        with connection.cursor() as cursor:
+            result = connection.introspection.get_constraints(
+                cursor, "backends_modelwithindexes"
+            )
+
+        index = result["single_idx_w_name"]
+        self.assertEqual(index["columns"], ["single_idx_field_w_name"])
+        # YDB secondary indexes are non-unique and ascending.
+        self.assertFalse(index["unique"])
+        self.assertFalse(index["primary_key"])
+        self.assertTrue(index["index"])
+        self.assertEqual(index["orders"], ["ASC"])

--- a/tests/backends/ydb/test_schema.py
+++ b/tests/backends/ydb/test_schema.py
@@ -1,10 +1,14 @@
+from django.db import NotSupportedError
 from django.db import connection
 from django.db import models
 from django.db.models import CASCADE
+from django.db.models import CheckConstraint
 from django.db.models import ForeignKey
 from django.db.models import Index
 from django.db.models import IntegerField
+from django.db.models import Q
 from django.db.models import TextField
+from django.db.models import UniqueConstraint
 from django.test import TransactionTestCase
 
 from ..models import DbColumnModel
@@ -110,12 +114,7 @@ class TestDatabaseSchema(TransactionTestCase):
                 field_to_remove
             )
 
-        with connection.cursor() as cursor:
-            self.assertTrue(
-                len(connection.introspection.get_sequences(
-                    cursor,
-                    "backends_mymodel"
-                )) > 3)
+        self.assertIn("patronymic", _get_columns("backends_mymodel"))
 
         with connection.schema_editor() as editor:
             editor.remove_field(
@@ -123,11 +122,7 @@ class TestDatabaseSchema(TransactionTestCase):
                 field_to_remove
             )
 
-        with connection.cursor() as cursor:
-            self.assertTrue(
-                len(connection.introspection.get_sequences(
-                    cursor, "backends_mymodel"
-                )) > 2)
+        self.assertNotIn("patronymic", _get_columns("backends_mymodel"))
 
     def test_create_model_with_db_column(self):
         columns = _get_columns("backends_dbcolumnmodel")
@@ -243,3 +238,111 @@ class TestDatabaseSchema(TransactionTestCase):
 
         index_true = _get_indexes()
         self.assertNotIn("composite_idx_w_name", index_true)
+
+
+def _named_field(field_class, name, **kwargs):
+    field = field_class(**kwargs)
+    field.set_attributes_from_name(name)
+    return field
+
+
+_SCHEMA_LOGGER = "django_ydb_backend.ydb_backend.backend.schema"
+
+
+class TestUnsupportedSchemaOperations(TransactionTestCase):
+    """
+    YDB cannot enforce constraints or alter existing columns. Operations that
+    would corrupt the schema (rename/type/PK change) must fail loudly; those
+    that only drop an unenforceable guarantee (constraints, uniqueness,
+    nullability) are skipped with a warning so ``migrate`` of stock Django apps
+    keeps working instead of silently passing (issue #35).
+    """
+
+    databases = {"default"}
+
+    def _assert_raises(self, method_name, *args):
+        editor = connection.schema_editor()
+        with self.assertRaises(NotSupportedError):
+            getattr(editor, method_name)(*args)
+
+    def _assert_warns(self, method_name, *args):
+        editor = connection.schema_editor()
+        with self.assertLogs(_SCHEMA_LOGGER, level="WARNING"):
+            getattr(editor, method_name)(*args)
+
+    def test_add_unique_constraint_warns(self):
+        constraint = UniqueConstraint(fields=["name"], name="uq_mymodel_name")
+        self._assert_warns("add_constraint", MyModel, constraint)
+
+    def test_add_check_constraint_warns(self):
+        constraint = CheckConstraint(check=Q(id__gte=0), name="ck_mymodel_id")
+        self._assert_warns("add_constraint", MyModel, constraint)
+
+    def test_remove_constraint_is_noop(self):
+        constraint = UniqueConstraint(fields=["name"], name="uq_mymodel_name")
+        # Nothing was ever created, so dropping it must not raise.
+        connection.schema_editor().remove_constraint(MyModel, constraint)
+
+    def test_alter_field_type_change_raises(self):
+        old_field = _named_field(IntegerField, "name")
+        new_field = _named_field(TextField, "name")
+        self._assert_raises("alter_field", MyModel, old_field, new_field)
+
+    def test_alter_field_rename_raises(self):
+        old_field = _named_field(IntegerField, "old_name")
+        new_field = _named_field(IntegerField, "new_name")
+        self._assert_raises("alter_field", MyModel, old_field, new_field)
+
+    def test_alter_field_primary_key_change_raises(self):
+        old_field = _named_field(IntegerField, "name")
+        new_field = _named_field(IntegerField, "name", primary_key=True)
+        self._assert_raises("alter_field", MyModel, old_field, new_field)
+
+    def test_alter_field_nullability_change_warns(self):
+        old_field = _named_field(IntegerField, "name", null=False)
+        new_field = _named_field(IntegerField, "name", null=True)
+        self._assert_warns("alter_field", MyModel, old_field, new_field)
+
+    def test_alter_field_add_unique_warns(self):
+        old_field = _named_field(IntegerField, "name")
+        new_field = _named_field(IntegerField, "name", unique=True)
+        self._assert_warns("alter_field", MyModel, old_field, new_field)
+
+    def test_alter_field_default_change_is_noop(self):
+        # Defaults are not stored in YDB, so changing one is a harmless no-op.
+        old_field = _named_field(IntegerField, "name", default=1)
+        new_field = _named_field(IntegerField, "name", default=2)
+        connection.schema_editor().alter_field(MyModel, old_field, new_field)
+
+    def test_alter_unique_together_add_warns(self):
+        self._assert_warns(
+            "alter_unique_together", MyModel, [], [("id", "name")]
+        )
+
+    def test_alter_unique_together_clear_is_noop(self):
+        connection.schema_editor().alter_unique_together(
+            MyModel, [("id", "name")], []
+        )
+
+    def test_alter_field_db_index_add_and_drop(self):
+        def index_columns():
+            with connection.cursor() as cursor:
+                constraints = connection.introspection.get_constraints(
+                    cursor, "backends_mymodel"
+                )
+            return [
+                value["columns"]
+                for value in constraints.values()
+                if value["index"] and not value["primary_key"]
+            ]
+
+        no_index = _named_field(TextField, "name")
+        indexed = _named_field(TextField, "name", db_index=True)
+
+        with connection.schema_editor() as editor:
+            editor.alter_field(MyModel, no_index, indexed)
+        self.assertIn(["name"], index_columns())
+
+        with connection.schema_editor() as editor:
+            editor.alter_field(MyModel, indexed, no_index)
+        self.assertNotIn(["name"], index_columns())

--- a/tests/backends/ydb/test_schema.py
+++ b/tests/backends/ydb/test_schema.py
@@ -1,3 +1,4 @@
+import django
 from django.db import NotSupportedError
 from django.db import connection
 from django.db import models
@@ -275,7 +276,12 @@ class TestUnsupportedSchemaOperations(TransactionTestCase):
         self._assert_warns("add_constraint", MyModel, constraint)
 
     def test_add_check_constraint_warns(self):
-        constraint = CheckConstraint(check=Q(id__gte=0), name="ck_mymodel_id")
+        # CheckConstraint.check was renamed to .condition in Django 5.1 and
+        # removed in 6.0.
+        if django.VERSION >= (5, 1):
+            constraint = CheckConstraint(condition=Q(id__gte=0), name="ck_mymodel")
+        else:
+            constraint = CheckConstraint(check=Q(id__gte=0), name="ck_mymodel")
         self._assert_warns("add_constraint", MyModel, constraint)
 
     def test_remove_constraint_is_noop(self):

--- a/ydb_backend/backend/base.py
+++ b/ydb_backend/backend/base.py
@@ -127,9 +127,14 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     #     return self.connection._driver
 
     def get_table_names(self):
+        # Introspection may be the first database operation in a request (e.g.
+        # `flush`/`migrate`), so make sure the underlying connection is open
+        # before reaching into it.
+        self.ensure_connection()
         return self.connection.get_table_names()
 
     def get_describe(self, table_name):
+        self.ensure_connection()
         return self.connection.describe(table_name)
 
     @staticmethod

--- a/ydb_backend/backend/introspection.py
+++ b/ydb_backend/backend/introspection.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 
+import ydb
 from django.db.backends.base.introspection import BaseDatabaseIntrospection
 from django.db.backends.base.introspection import FieldInfo as BaseFieldInfo
 from django.db.backends.base.introspection import TableInfo as BaseTableInfo
@@ -7,34 +8,63 @@ from django.db.backends.base.introspection import TableInfo as BaseTableInfo
 FieldInfo = namedtuple("FieldInfo", BaseFieldInfo._fields)
 TableInfo = namedtuple("TableInfo", BaseTableInfo._fields)
 
+# YDB primitive type names that back Django auto-increment (Serial) primary
+# keys. YDB does not expose "Serial" through describe() — a Serial column is
+# reported as its underlying integer type — so an integer primary key is the
+# only signal available for auto-increment detection.
+_INTEGER_TYPE_NAMES = frozenset(
+    {
+        "Int8",
+        "Int16",
+        "Int32",
+        "Int64",
+        "Uint8",
+        "Uint16",
+        "Uint32",
+        "Uint64",
+    }
+)
 
-def _create_sequences_info(table_name, column_name):
-    sequences = []
-    for field in column_name:
-        sequence_info = {
-            "table_name": table_name,
-            "column_name": field.name,
-        }
-        sequences.append(sequence_info)
-    return sequences
+
+def _resolve_base_type(column_type):
+    """
+    Unwrap a YDB ``Optional<T>`` column type, returning ``(base_type,
+    is_nullable)``. Non-optional columns are NOT NULL.
+    """
+    if isinstance(column_type, ydb.OptionalType):
+        return column_type.item, True
+    return column_type, False
+
+
+def _ydb_type_name(base_type):
+    """Stable string key for a YDB column base type, e.g. ``Int32``/``Decimal``."""
+    if isinstance(base_type, ydb.DecimalType):
+        return "Decimal"
+    return getattr(base_type, "name", str(base_type))
 
 
 def _create_table_desc_info(columns):
-    sequences = []
-    for field in columns:
-        sequence_info = FieldInfo(
-            name=field.name,
-            type_code=str(field.type),
-            display_size=None,  # TODO: fill attributes with values
-            internal_size=None,
-            precision=None,
-            scale=None,
-            null_ok=None,
-            default=None,
-            collation=None,
+    fields = []
+    for column in columns:
+        base_type, is_nullable = _resolve_base_type(column.type)
+        precision = scale = None
+        if isinstance(base_type, ydb.DecimalType):
+            precision = base_type.precision
+            scale = base_type.scale
+        fields.append(
+            FieldInfo(
+                name=column.name,
+                type_code=_ydb_type_name(base_type),
+                display_size=None,
+                internal_size=None,
+                precision=precision,
+                scale=scale,
+                null_ok=is_nullable,
+                default=None,
+                collation=None,
+            )
         )
-        sequences.append(sequence_info)
-    return sequences
+    return fields
 
 
 def _create_table_info(table_scheme_entry):
@@ -51,15 +81,17 @@ def _get_constraint_tuple(
     foreign_key=None,
     is_check=False,
     is_index=True,
+    orders=None,
     _type=None,
 ):
     return {
-        "columns": columns,
+        "columns": list(columns),
         "primary_key": is_primary_key,
-        "unique": is_unique,  # TODO: for indexes define
+        "unique": is_unique,
         "foreign_key": foreign_key,
         "check": is_check,
         "index": is_index,
+        "orders": orders,
         "type": _type,
     }
 
@@ -67,54 +99,58 @@ def _get_constraint_tuple(
 class DatabaseIntrospection(BaseDatabaseIntrospection):
     """Encapsulate backends-specific introspection utilities."""
 
+    # Reverse mapping from a YDB column type name (as produced by
+    # _ydb_type_name and stored in FieldInfo.type_code) to a Django field type.
+    # Used by Django introspection and `inspectdb`. The mapping is necessarily
+    # lossy because several Django fields share one YDB type (e.g. CharField and
+    # TextField both map to Utf8).
     data_types_reverse = {
-        0: "AutoField",
-        1: "BigAutoField",
-        2: "BinaryField",
-        3: "BooleanField",
-        4: "CharField",
-        5: "DateField",
-        6: "DateTimeField",
-        7: "DecimalField",
-        8: "DurationField",
-        9: "FileField",
-        10: "FilePathField",
-        11: "FloatField",
-        12: "DoubleField",
-        13: "IntegerField",
-        14: "BigIntegerField",
-        15: "IPAddressField",
-        16: "GenericIPAddressField",
-        17: "NullBooleanField",
-        18: "PositiveIntegerField",
-        19: "PositiveBigIntegerField",
-        20: "PositiveSmallIntegerField",
-        21: "SlugField",
-        22: "SmallAutoField",
-        23: "SmallIntegerField",
-        24: "TextField",
-        25: "UUIDField",
-        26: "JSONField",
-        27: "EnumField",
-        28: "EmailField",
+        "Bool": "BooleanField",
+        "Int8": "SmallIntegerField",
+        "Int16": "SmallIntegerField",
+        "Int32": "IntegerField",
+        "Int64": "BigIntegerField",
+        "Uint8": "PositiveSmallIntegerField",
+        "Uint16": "PositiveSmallIntegerField",
+        "Uint32": "PositiveIntegerField",
+        "Uint64": "PositiveBigIntegerField",
+        "Float": "FloatField",
+        "Double": "FloatField",
+        "Decimal": "DecimalField",
+        "Utf8": "TextField",
+        "String": "BinaryField",
+        "Json": "JSONField",
+        "JsonDocument": "JSONField",
+        "Yson": "TextField",
+        "UUID": "UUIDField",
+        "Date": "DateField",
+        "Datetime": "DateTimeField",
+        "Timestamp": "DateTimeField",
+        "Interval": "DurationField",
     }
+
+    def get_yql_type(self, internal_type):
+        """
+        Forward map a Django field internal type to the YQL type string used in
+        ``DECLARE`` statements. Auto-increment fields are declared as their
+        underlying integer type because ``Serial`` cannot be used as a
+        parameter type.
+        """
+        if internal_type == "SmallAutoField":
+            return "Int16"
+        if internal_type == "AutoField":
+            return "Int32"
+        if internal_type == "BigAutoField":
+            return "Int64"
+        return self.connection.data_types[internal_type]
 
     def get_field_type(self, data_type, description):
         """
-        Hook for a database backends to use the cursor description to
-        match a Django field type to a database column.
-
-        For Oracle, the column data_type on its own is insufficient to
-        distinguish between a FloatField and IntegerField, for example.
+        Hook for a database backend to use the cursor description to match a
+        Django field type to a database column. ``data_type`` is the YDB type
+        name stored in ``FieldInfo.type_code``.
         """
-        if data_type == "SmallAutoField":
-            return "Int16"
-        if data_type == "AutoField":
-            return "Int32"
-        if data_type == "BigAutoField":
-            return "Int64"
-
-        return self.connection.data_types[data_type]
+        return self.data_types_reverse.get(data_type, "TextField")
 
     def identifier_converter(self, name):
         """
@@ -160,11 +196,22 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
     def get_sequences(self, cursor, table_name, table_fields=()):
         """
         Return a list of introspected sequences for table_name. Each sequence
-        is a dict: {'table': <table_name>, 'column': <column_name>}. An optional
-        'name' key can be added if the backends supports named sequences.
+        is a dict: {'table': <table_name>, 'column': <column_name>}.
+
+        YDB does not expose Serial metadata through describe(), so only
+        integer primary key columns (the shape produced by Django's auto
+        fields) are reported as sequences.
         """
         table_scheme_entry = self.connection.get_describe(table_name)
-        return _create_sequences_info(table_name, table_scheme_entry.columns)
+        primary_key = set(table_scheme_entry.primary_key)
+        sequences = []
+        for column in table_scheme_entry.columns:
+            if column.name not in primary_key:
+                continue
+            base_type, _ = _resolve_base_type(column.type)
+            if _ydb_type_name(base_type) in _INTEGER_TYPE_NAMES:
+                sequences.append({"table": table_name, "column": column.name})
+        return sequences
 
     def get_relations(self, cursor, table_name):
         """
@@ -179,7 +226,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         Return a list of primary key columns for the given table.
         """
         table_scheme_entry = self.connection.get_describe(table_name)
-        return table_scheme_entry.primary_key
+        return list(table_scheme_entry.primary_key)
 
     def get_constraints(self, cursor, table_name):
         """
@@ -197,26 +244,30 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         * orders: The order (ASC/DESC) defined for the columns of indexes
         * type: The type of the index (btree, hash, etc.)
 
-        Some backends may return special constraint names that don't exist
-        if they don't name constraints of a certain type (e.g. SQLite)
+        YDB exposes neither foreign keys nor check constraints, and its
+        secondary indexes are not unique, so those are reported accordingly.
         """
         constraints = {}
         table_scheme_entry = self.connection.get_describe(table_name)
 
         if table_scheme_entry.primary_key:
+            pk_columns = list(table_scheme_entry.primary_key)
             constraints["primary_key"] = _get_constraint_tuple(
-                columns=table_scheme_entry.primary_key,
+                columns=pk_columns,
                 is_primary_key=True,
                 is_unique=True,
+                orders=["ASC"] * len(pk_columns),
             )
 
         for index in table_scheme_entry.indexes:
-            index_name = index.name
-            columns = index.index_columns
-            constraints[index_name] = _get_constraint_tuple(
+            columns = list(index.index_columns)
+            constraints[index.name] = _get_constraint_tuple(
                 columns=columns,
                 is_primary_key=False,
-                is_unique=None,
+                # YDB secondary indexes do not enforce uniqueness.
+                is_unique=False,
+                orders=["ASC"] * len(columns),
+                _type="global",
             )
 
         return constraints

--- a/ydb_backend/backend/schema.py
+++ b/ydb_backend/backend/schema.py
@@ -6,6 +6,7 @@ from datetime import timezone
 from enum import Enum
 from uuid import UUID
 
+from django.db import NotSupportedError
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.backends.ddl_references import Columns
 from django.db.backends.ddl_references import Statement
@@ -343,15 +344,86 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
 
     def add_constraint(self, model, constraint):
         """
-        YDB does not support constraints - for Django compatibility only
-        User applications must enforce constraints at application level.
+        YDB enforces neither uniqueness nor check constraints.
+
+        The constraint is skipped with a warning rather than created: a hard
+        error would break ``migrate`` for stock Django apps (django.contrib.*
+        ship unique constraints), while silently materialising it would imply
+        an integrity guarantee YDB cannot provide. Enforce such invariants in
+        application code.
         """
+        logger.warning(
+            "YDB does not support database constraints; skipping %s %r on %r. "
+            "Enforce this constraint in application code.",
+            type(constraint).__name__,
+            getattr(constraint, "name", None),
+            model._meta.db_table,
+        )
 
     def remove_constraint(self, model, constraint):
         """
-        YDB does not support constraints - for Django compatibility only
-        User applications must enforce constraints at application level.
+        No-op: constraints are never created on YDB (see ``add_constraint``),
+        so there is nothing to drop. Kept for migration-executor compatibility.
         """
+
+    def alter_field(self, model, old_field, new_field, strict=False):
+        """
+        Apply the parts of a field alteration YDB supports and surface the rest
+        instead of emitting broken DDL.
+
+        Changes that would corrupt the schema (column rename, type change,
+        primary-key change) raise ``NotSupportedError`` because the model and
+        table would diverge and queries break. Changes YDB cannot apply but
+        that keep the table queryable (nullability, newly added uniqueness) are
+        skipped with a warning so ``migrate`` of stock Django apps keeps
+        working; uniqueness in particular is never enforced by YDB. Purely
+        cosmetic changes (default, help_text, verbose_name, choices, ...) are
+        no-ops, and a ``db_index`` change is applied as a secondary index.
+        """
+        old_db_params = old_field.db_parameters(connection=self.connection)
+        new_db_params = new_field.db_parameters(connection=self.connection)
+        db_table = model._meta.db_table
+
+        if old_field.column != new_field.column:
+            error_message = (
+                f"YDB cannot rename column {old_field.column!r} to "
+                f"{new_field.column!r} on {db_table!r}."
+            )
+            raise NotSupportedError(error_message)
+        if (old_db_params["type"] or "") != (new_db_params["type"] or ""):
+            error_message = (
+                f"YDB cannot change the type of column {new_field.column!r} on "
+                f"{db_table!r} ({old_db_params['type']} -> "
+                f"{new_db_params['type']})."
+            )
+            raise NotSupportedError(error_message)
+        if old_field.primary_key != new_field.primary_key:
+            error_message = f"YDB cannot alter the primary key of {db_table!r}."
+            raise NotSupportedError(error_message)
+
+        if old_field.null != new_field.null:
+            logger.warning(
+                "YDB cannot change the nullability of column %r on %r after "
+                "creation; skipping.",
+                new_field.column,
+                db_table,
+            )
+        if new_field.unique and not old_field.unique:
+            logger.warning(
+                "YDB does not enforce uniqueness for column %r on %r; skipping. "
+                "Enforce it in application code.",
+                new_field.column,
+                db_table,
+            )
+
+        # Adding or dropping a secondary index for the field is supported.
+        if old_field.db_index and not new_field.db_index:
+            for index_name in self._constraint_names(
+                model, [old_field.column], index=True
+            ):
+                self.execute(self._delete_index_sql(model, index_name))
+        elif new_field.db_index and not old_field.db_index:
+            self.deferred_sql.extend(self._field_indexes_sql(model, new_field))
 
     def alter_db_table_comment(self, model, old_db_table_comment, new_db_table_comment):
         """
@@ -367,9 +439,20 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
 
     def alter_unique_together(self, model, old_unique_together, new_unique_together):
         """
-        YDB does not enforce unique constraints
-        For Django compatibility only - implement uniqueness checks in app logic
+        YDB does not enforce uniqueness. A newly added ``unique_together`` is
+        skipped with a warning (so ``migrate`` of apps such as
+        django.contrib.contenttypes keeps working); clearing one is a no-op.
         """
+        old = {tuple(fields) for fields in (old_unique_together or ())}
+        new = {tuple(fields) for fields in (new_unique_together or ())}
+        added = new - old
+        if added:
+            logger.warning(
+                "YDB does not enforce unique_together %s on %r; skipping. "
+                "Enforce uniqueness in application code.",
+                sorted(added),
+                model._meta.db_table,
+            )
 
     def _alter_column_null_sql(self, model, old_field, new_field):
         """

--- a/ydb_backend/models/sql/compiler.py
+++ b/ydb_backend/models/sql/compiler.py
@@ -419,8 +419,8 @@ class BaseSQLWriteCompiler(compiler.SQLInsertCompiler):
 
         field_types = []
         for f in fields:
-            yql_type = self.connection.introspection.get_field_type(
-                _get_field_internal_type(f), {}
+            yql_type = self.connection.introspection.get_yql_type(
+                _get_field_internal_type(f)
             )
             if getattr(f, "null", False):
                 yql_type = f"Optional<{yql_type}>"


### PR DESCRIPTION
Closes #45. Closes #35.

## Introspection (#45)
- Accurate nullability from YDB `Optional<T>` (was always `None`).
- Sequences only for integer primary keys, using Django's `{table, column}` contract (keys were non-standard).
- Secondary indexes reported as non-unique, with `orders`.
- Correct reverse type mapping for `inspectdb`; the forward DECLARE mapping moved to `get_yql_type`, called by the insert/upsert compilers.

## Schema operations (#35)
Unsupported operations are no longer silent no-ops:
- **Warn + skip** for unenforceable-but-non-corrupting changes (unique/check constraints, `unique_together`, nullability). This keeps `migrate` of stock contrib apps working — verified `contenttypes` + `auth` migrate to completion.
- **Raise `NotSupportedError`** for schema-corrupting changes (column rename, type change, primary-key change).

## Also
- Fix introspection crashing (`NoneType`) when it is the first DB operation, by ensuring the connection in `get_table_names`/`get_describe`.
- `docs/MIGRATIONS.md` updated to match behavior + inspectdb notes.

Tests: introspection updated for accurate values + new cases; `TestUnsupportedSchemaOperations` covers raise/warn/no-op paths. Full suite green (210), `ruff check` clean.

Note: full admin/auth still needs auto-created M2M through tables (#39), out of scope here.