### PR TITLE
feat: auto-created M2M through tables (#39)

### DIFF
--- a/docs/MIGRATIONS.md
+++ b/docs/MIGRATIONS.md
@@ -56,6 +56,17 @@ application logic.
 
 **Solution:** Data integrity control is assigned to the application logic.
 
+## Relations and many-to-many
+
+Relations are stored as plain scalar columns (`<name>_id`) typed from the
+target's primary key; no `FOREIGN KEY`, `REFERENCES` or `ON DELETE` SQL is
+emitted, and referential integrity is left to the application.
+
+Auto-created many-to-many through tables are created and dropped together with
+their model (just like Django's base schema editor), so `ManyToManyField`
+add/list/remove works at the ORM level. Custom (`through=`) models are created
+as ordinary tables.
+
 ## Indexes
 **Features:**
 - Indexes are created via ADD INDEX ... GLOBAL (as in the code example) or are set when creating table.

--- a/tests/m2m/models.py
+++ b/tests/m2m/models.py
@@ -1,0 +1,96 @@
+import uuid
+
+from django.db import models
+
+
+# --- Auto-created through, integer target PK ---
+class IntTag(models.Model):
+    name = models.CharField(max_length=50)
+
+    def __str__(self):
+        return self.name
+
+
+class Article(models.Model):
+    title = models.CharField(max_length=100)
+    tags = models.ManyToManyField(IntTag, related_name="articles")
+
+    def __str__(self):
+        return self.title
+
+
+# --- Auto-created through, string target PK ---
+class StrItem(models.Model):
+    code = models.CharField(max_length=20, primary_key=True)
+
+    def __str__(self):
+        return self.code
+
+
+class StrBox(models.Model):
+    name = models.CharField(max_length=50)
+    items = models.ManyToManyField(StrItem)
+
+    def __str__(self):
+        return self.name
+
+
+# --- Auto-created through, UUID target PK ---
+class UuidItem(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4)
+    label = models.CharField(max_length=50)
+
+    def __str__(self):
+        return self.label
+
+
+class UuidBox(models.Model):
+    name = models.CharField(max_length=50)
+    items = models.ManyToManyField(UuidItem)
+
+    def __str__(self):
+        return self.name
+
+
+# --- Auto-created through, big integer target PK ---
+class BigItem(models.Model):
+    id = models.BigAutoField(primary_key=True)
+    label = models.CharField(max_length=50)
+
+    def __str__(self):
+        return self.label
+
+
+class BigBox(models.Model):
+    name = models.CharField(max_length=50)
+    items = models.ManyToManyField(BigItem)
+
+    def __str__(self):
+        return self.name
+
+
+# --- Custom (user-defined) through model ---
+class Club(models.Model):
+    name = models.CharField(max_length=50)
+
+    def __str__(self):
+        return self.name
+
+
+class Member(models.Model):
+    name = models.CharField(max_length=50)
+    clubs = models.ManyToManyField(
+        Club, through="Membership", related_name="members"
+    )
+
+    def __str__(self):
+        return self.name
+
+
+class Membership(models.Model):
+    member = models.ForeignKey(Member, on_delete=models.CASCADE)
+    club = models.ForeignKey(Club, on_delete=models.CASCADE)
+    role = models.CharField(max_length=30)
+
+    def __str__(self):
+        return f"{self.member} in {self.club} as {self.role}"

--- a/tests/m2m/test_m2m.py
+++ b/tests/m2m/test_m2m.py
@@ -68,10 +68,17 @@ class TestAutoCreatedM2M(TransactionTestCase):
             )
 
     def test_through_columns_integer_target(self):
+        # The auto PK type depends on DEFAULT_AUTO_FIELD (AutoField -> Int32,
+        # BigAutoField -> Int64, the Django 6.0 default), so assert the through
+        # column matches the target's actual primary key type.
         through = Article.tags.through
         column = _target_relation_column(through, IntTag)
-        types = _column_types(through._meta.db_table)
-        self.assertEqual(types[column], "Int32")
+        through_types = _column_types(through._meta.db_table)
+        target_pk_type = _column_types(IntTag._meta.db_table)[
+            IntTag._meta.pk.column
+        ]
+        self.assertEqual(through_types[column], target_pk_type)
+        self.assertIn(target_pk_type, ("Int32", "Int64"))
 
     def test_through_columns_string_target(self):
         through = StrBox.items.through

--- a/tests/m2m/test_m2m.py
+++ b/tests/m2m/test_m2m.py
@@ -1,0 +1,121 @@
+from django.db import connection
+from django.test import TransactionTestCase
+
+from .models import Article
+from .models import BigBox
+from .models import BigItem
+from .models import Club
+from .models import IntTag
+from .models import Member
+from .models import Membership
+from .models import StrBox
+from .models import StrItem
+from .models import UuidBox
+from .models import UuidItem
+
+
+def _column_types(table_name):
+    with connection.cursor() as cursor:
+        description = connection.introspection.get_table_description(
+            cursor, table_name
+        )
+    return {field.name: field.type_code for field in description}
+
+
+def _target_relation_column(through, target_model):
+    for field in through._meta.fields:
+        if field.is_relation and field.remote_field.model is target_model:
+            return field.column
+    message = f"no relation column to {target_model!r}"
+    raise AssertionError(message)
+
+
+class TestAutoCreatedM2M(TransactionTestCase):
+    databases = {"default"}
+
+    def test_auto_through_table_exists(self):
+        through_table = Article.tags.through._meta.db_table
+        self.assertIn(through_table, connection.introspection.table_names())
+
+    def test_add_list_remove(self):
+        article = Article.objects.create(title="Backends")
+        ydb = IntTag.objects.create(name="ydb")
+        django = IntTag.objects.create(name="django")
+
+        article.tags.add(ydb, django)
+        self.assertEqual(
+            set(article.tags.values_list("name", flat=True)),
+            {"ydb", "django"},
+        )
+
+        # Reverse accessor goes through the same auto-created table.
+        self.assertIn(article, ydb.articles.all())
+
+        article.tags.remove(ydb)
+        self.assertEqual(
+            list(article.tags.values_list("name", flat=True)),
+            ["django"],
+        )
+
+        article.tags.clear()
+        self.assertEqual(article.tags.count(), 0)
+
+    def test_no_foreign_key_constraints_reported(self):
+        through_table = Article.tags.through._meta.db_table
+        with connection.cursor() as cursor:
+            self.assertEqual(
+                connection.introspection.get_relations(cursor, through_table), {}
+            )
+
+    def test_through_columns_integer_target(self):
+        through = Article.tags.through
+        column = _target_relation_column(through, IntTag)
+        types = _column_types(through._meta.db_table)
+        self.assertEqual(types[column], "Int32")
+
+    def test_through_columns_string_target(self):
+        through = StrBox.items.through
+        column = _target_relation_column(through, StrItem)
+        types = _column_types(through._meta.db_table)
+        self.assertEqual(types[column], "Utf8")
+
+    def test_through_columns_uuid_target(self):
+        through = UuidBox.items.through
+        column = _target_relation_column(through, UuidItem)
+        types = _column_types(through._meta.db_table)
+        self.assertEqual(types[column], "UUID")
+
+    def test_through_columns_big_integer_target(self):
+        through = BigBox.items.through
+        column = _target_relation_column(through, BigItem)
+        types = _column_types(through._meta.db_table)
+        self.assertEqual(types[column], "Int64")
+
+    def test_string_pk_m2m_round_trip(self):
+        box = StrBox.objects.create(name="box")
+        item = StrItem.objects.create(code="ABC")
+        box.items.add(item)
+        self.assertIn(item, box.items.all())
+
+
+class TestCustomThroughM2M(TransactionTestCase):
+    databases = {"default"}
+
+    def test_custom_through_is_a_regular_table(self):
+        # A user-defined through model is created as an ordinary model, not as
+        # an auto-created M2M table.
+        self.assertFalse(Member.clubs.through._meta.auto_created)
+        self.assertIn(
+            Membership._meta.db_table, connection.introspection.table_names()
+        )
+
+    def test_custom_through_round_trip(self):
+        member = Member.objects.create(name="Ada")
+        club = Club.objects.create(name="Pioneers")
+        Membership.objects.create(member=member, club=club, role="founder")
+
+        self.assertIn(club, member.clubs.all())
+        self.assertIn(member, club.members.all())
+        self.assertEqual(
+            Membership.objects.get(member=member, club=club).role, "founder"
+        )

--- a/ydb_backend/backend/schema.py
+++ b/ydb_backend/backend/schema.py
@@ -325,8 +325,21 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         # _remake_table needs it).
         self.deferred_sql.extend(self._model_indexes_sql(model))
 
+        # Auto-created M2M through tables are plain tables carrying two relation
+        # columns; mirror Django's base schema editor and create them too.
+        # Custom (user-defined) through models are created as ordinary models,
+        # so they are skipped here.
+        for field in model._meta.local_many_to_many:
+            if field.remote_field.through._meta.auto_created:
+                self.create_model(field.remote_field.through)
+
     def delete_model(self, model):
         """Delete a model from the database."""
+
+        # Drop the auto-created M2M through tables before the model table.
+        for field in model._meta.local_many_to_many:
+            if field.remote_field.through._meta.auto_created:
+                self.delete_model(field.remote_field.through)
 
         # Delete the table
         self.execute(


### PR DESCRIPTION
Closes #39.

Django's base schema editor creates auto-created M2M through tables during `create_model()`; the backend override did not, so `ManyToManyField` tables (e.g. `auth_group_permissions`) were never created.

- `create_model`: also create auto-created through tables for local M2M fields.
- `delete_model`: drop them before the model table.
- Custom (`through=`) models are left to be created as ordinary tables.

Through tables are plain tables with `*_id` columns typed from the target primary key; no FK/`REFERENCES`/`ON DELETE` SQL is emitted (referential integrity stays in the app, as elsewhere in the backend).

Tests (`tests/m2m/`): ORM add/list/remove/clear + reverse accessors, custom-through round-trip, and through-column types for integer/string/UUID/big-integer target PKs. Verified end-to-end that `migrate auth` now creates `auth_group_permissions`, `auth_user_groups`, `auth_user_user_permissions`.

Full suite green (220), `ruff check` clean. `docs/MIGRATIONS.md` updated with a relations/M2M section.