### PR TITLE
fix: read auto-increment keys via INSERT ... RETURNING (#44)

### DIFF
--- a/tests/backends/ydb/test_features.py
+++ b/tests/backends/ydb/test_features.py
@@ -36,7 +36,7 @@ class TestFeatureFlags(SimpleTestCase):
         self.assertFalse(f.supports_partially_nullable_unique_constraints)
         self.assertFalse(f.allows_multiple_constraints_on_same_fields)
         # bulk insert
-        self.assertFalse(f.can_return_rows_from_bulk_insert)
+        self.assertTrue(f.can_return_rows_from_bulk_insert)
         self.assertFalse(f.supports_ignore_conflicts)
         # transactions / savepoints
         self.assertTrue(f.supports_transactions)

--- a/tests/compiler/test_insert_returning.py
+++ b/tests/compiler/test_insert_returning.py
@@ -1,0 +1,96 @@
+"""
+Regression tests for issue #44: auto-increment primary keys are read back with
+INSERT ... RETURNING (the actual generated ids), not by selecting MAX(pk) and
+assuming contiguous ids.
+"""
+
+from datetime import date
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+
+from django.test import TransactionTestCase
+
+from type.models import NullableFieldsModel
+from type.models import TimeModel
+
+from .models import EventRecord
+from .models import Product
+
+
+class TestInsertReturning(TransactionTestCase):
+    databases = {"default"}
+
+    def test_single_auto_pk(self):
+        obj = EventRecord.objects.create(name="one")
+        self.assertIsNotNone(obj.pk)
+        self.assertEqual(EventRecord.objects.get(name="one").pk, obj.pk)
+
+    def test_bulk_auto_pk_sets_each_pk(self):
+        objs = EventRecord.objects.bulk_create(
+            [EventRecord(name=f"b{i}") for i in range(5)]
+        )
+        pks = [o.pk for o in objs]
+        self.assertTrue(all(pk is not None for pk in pks))
+        self.assertEqual(len(set(pks)), 5)
+        # Each returned pk maps to the right row (order preserved).
+        for obj in objs:
+            self.assertEqual(EventRecord.objects.get(pk=obj.pk).name, obj.name)
+
+    def test_returned_pk_is_own_not_global_max(self):
+        # A pre-existing row with a high pk (as a concurrent writer would leave)
+        # must not be mistaken for this insert's generated id.
+        EventRecord.objects.create(pk=999999, name="high")
+        obj = EventRecord.objects.create(name="mine")
+        self.assertNotEqual(obj.pk, 999999)
+        self.assertEqual(EventRecord.objects.get(name="mine").pk, obj.pk)
+
+    def test_explicit_pk_single(self):
+        obj = EventRecord.objects.create(pk=777, name="explicit")
+        self.assertEqual(obj.pk, 777)
+        self.assertTrue(EventRecord.objects.filter(pk=777).exists())
+
+    def test_explicit_pk_bulk(self):
+        objs = EventRecord.objects.bulk_create(
+            [EventRecord(pk=100 + i, name=f"e{i}") for i in range(3)]
+        )
+        self.assertEqual([o.pk for o in objs], [100, 101, 102])
+        self.assertEqual(
+            EventRecord.objects.filter(pk__in=[100, 101, 102]).count(), 3
+        )
+
+    def test_non_auto_pk(self):
+        obj = Product.objects.create(
+            sku="ABC", name="x", category="c", price=1, stock=1
+        )
+        self.assertEqual(obj.pk, "ABC")
+
+    def test_nullable_bulk(self):
+        objs = NullableFieldsModel.objects.bulk_create(
+            [
+                NullableFieldsModel(int_field=1, char_field=None),
+                NullableFieldsModel(int_field=None, char_field="x"),
+            ]
+        )
+        self.assertTrue(all(o.pk is not None for o in objs))
+        self.assertEqual(len({o.pk for o in objs}), 2)
+        self.assertEqual(NullableFieldsModel.objects.count(), 2)
+
+    def test_temporal_values_bulk(self):
+        moment = datetime(2023, 5, 15, 14, 30, tzinfo=timezone.utc)
+        objs = TimeModel.objects.bulk_create(
+            [
+                TimeModel(
+                    date_field=date(2023, 5, 15),
+                    datetime_field=moment,
+                    duration_field=timedelta(hours=2),
+                ),
+                TimeModel(
+                    date_field=date(2024, 1, 1),
+                    datetime_field=moment,
+                    duration_field=timedelta(days=1),
+                ),
+            ]
+        )
+        self.assertTrue(all(o.pk is not None for o in objs))
+        self.assertEqual(TimeModel.objects.count(), 2)

--- a/tests/type/test_auto_inc_fields.py
+++ b/tests/type/test_auto_inc_fields.py
@@ -117,4 +117,11 @@ class TestAutoIncFields(TransactionTestCase):
     def test_auto_field_sequence_after_manual_insert(self):
         SmallAutoIncModel.objects.create(small_id=32766, name="Manual Small")
         auto_obj = SmallAutoIncModel.objects.create(name="Auto Small")
-        self.assertTrue(auto_obj.small_id >= 32766)
+        # The serial generator is independent of manually inserted values;
+        # INSERT ... RETURNING returns the actual generated id, which must match
+        # the stored row (the old code returned MAX(pk) instead).
+        self.assertIsNotNone(auto_obj.small_id)
+        self.assertEqual(
+            SmallAutoIncModel.objects.get(name="Auto Small").small_id,
+            auto_obj.small_id,
+        )

--- a/ydb_backend/backend/features.py
+++ b/ydb_backend/backend/features.py
@@ -30,7 +30,9 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     # constraint exists and some fields are nullable but not all of them?
     supports_partially_nullable_unique_constraints = False
 
-    can_return_rows_from_bulk_insert = False
+    # YDB returns Serial keys via INSERT ... RETURNING (in input row order),
+    # so bulk_create can read back generated primary keys safely.
+    can_return_rows_from_bulk_insert = True
     uses_savepoints = False
 
     # Can a fixture contain forward references? i.e., are

--- a/ydb_backend/models/sql/compiler.py
+++ b/ydb_backend/models/sql/compiler.py
@@ -456,7 +456,7 @@ class SQLCompiler(_ParamTypingMixin, SQLCompiler):
 
 
 class BaseSQLWriteCompiler(compiler.SQLInsertCompiler):
-    def _prepare_sql_statement(self):
+    def _prepare_sql_statement(self, returning_columns=None):
         qn = self.connection.ops.quote_name
         opts = self.query.get_meta()
         fields = self.query.fields or [opts.pk]
@@ -471,11 +471,18 @@ class BaseSQLWriteCompiler(compiler.SQLInsertCompiler):
             field_types.append(f"{qn(f.column)}: {yql_type}")
         in_ = f"{', '.join(field_types)}"
 
+        select = (
+            f"SELECT {', '.join(qn(f.column) for f in fields)} FROM AS_TABLE($in_)"
+        )
+        if returning_columns:
+            # YDB returns database-generated keys (Serial) in input row order.
+            select += f" RETURNING {', '.join(qn(c) for c in returning_columns)}"
+
         return [
             f"DECLARE $in_ as List<Struct<{in_}>>;",
             f"{self._get_statement()} {qn(opts.db_table)}",
             f"({', '.join(qn(f.column) for f in fields)})",
-            f"SELECT {', '.join(qn(f.column) for f in fields)} FROM AS_TABLE($in_);"
+            f"{select};",
         ]
 
     def _prepare_params(self):
@@ -507,47 +514,44 @@ class BaseSQLWriteCompiler(compiler.SQLInsertCompiler):
     def _get_statement(self):
         raise NotImplementedError("Subclasses must implement this method")
 
-    def as_sql(self):
-        sql = self._prepare_sql_statement()
+    def as_sql(self, returning_columns=None):
+        sql = self._prepare_sql_statement(returning_columns)
         params = self._prepare_params()
         return [(" ".join(sql), params)]
 
     def execute_sql(self, returning_fields=None):
         opts = self.query.get_meta()
-
-        if (returning_fields is None
-                and hasattr(opts, "pk")
-                and isinstance(opts.pk, (
-                        models.AutoField,
-                        models.SmallAutoField,
-                        models.BigAutoField
-                ))):
+        auto_pk = isinstance(
+            opts.pk,
+            (models.AutoField, models.SmallAutoField, models.BigAutoField),
+        )
+        if returning_fields is None and auto_pk:
             returning_fields = [opts.pk]
 
+        # Read database-generated primary keys with RETURNING. When the PK is
+        # supplied with the row (explicit value or non-auto PK) its value is
+        # already known, so RETURNING is unnecessary.
+        pk_supplied = bool(self.query.fields) and opts.pk in self.query.fields
+        use_returning = bool(returning_fields) and auto_pk and not pk_supplied
+        returning_columns = [opts.pk.column] if use_returning else None
+
         with self.connection.cursor() as cursor:
-            for sql, params in self.as_sql():
+            returned = []
+            for sql, params in self.as_sql(returning_columns):
                 cursor.execute(sql, params)
+                if use_returning and cursor.description:
+                    returned = cursor.fetchall()
 
             if not returning_fields:
                 return []
 
-            num_objects = len(self.query.objs)
-            if num_objects > 1:
-                last_id = self.connection.ops.last_insert_id(
-                    cursor,
-                    opts.db_table,
-                    opts.pk.column
-                )
-                first_id = last_id - num_objects + 1
-                rows = [(idx,) for idx in range(first_id, last_id + 1)]
+            if use_returning:
+                rows = [tuple(row) for row in returned]
             else:
-                rows = [(
-                    self.connection.ops.last_insert_id(
-                        cursor,
-                        opts.db_table,
-                        opts.pk.column
-                    ),
-                )]
+                # The PK is already known; echo it back from the inserted rows.
+                rows = [
+                    (self.pre_save_val(opts.pk, obj),) for obj in self.query.objs
+                ]
 
             cols = [field.get_col(opts.db_table) for field in returning_fields]
             converters = self.get_converters(cols)


### PR DESCRIPTION
Closes #44.

The insert compiler reconstructed returned auto ids by selecting `MAX(pk)` and assuming contiguous ids for bulk inserts. That is unsafe under concurrency — a single insert could return another writer's id, and bulk inserts could return wrong ids.

`INSERT INTO ... SELECT ... FROM AS_TABLE($in_) RETURNING <pk>` returns the actual generated `Serial` keys in input row order, so each insert reads back its own ids. When the primary key is supplied with the row (an explicit value, or a non-auto PK) RETURNING is skipped and the already-known value is returned.

`can_return_rows_from_bulk_insert` is now `True`, so `bulk_create` populates primary keys.