### PR TITLE
docs: define and verify the transaction/autocommit contract (#36)

### DIFF
--- a/docs/TRANSACTIONS.md
+++ b/docs/TRANSACTIONS.md
@@ -1,0 +1,62 @@
+Transactions
+===
+
+The backend maps Django's transaction API onto YDB's interactive transactions.
+
+## What is supported
+
+- **`transaction.atomic()`** — the body runs in an interactive transaction.
+  On a clean exit the transaction is committed; on an exception (or
+  `transaction.set_rollback(True)`) it is rolled back.
+- **Autocommit** — outside an `atomic()` block every statement is its own
+  transaction (the default).
+- The connection stays usable after a rolled-back transaction.
+- Isolation level is `SERIALIZABLE` for interactive transactions.
+
+`supports_transactions` is `True`.
+
+## What is not supported
+
+- **Savepoints** (`uses_savepoints = False`). YDB has no savepoints, so nested
+  `atomic()` blocks are not independent: a nested block does not create a
+  savepoint, and an exception caught *inside* a nested block marks the whole
+  transaction for rollback — further queries then raise
+  `TransactionManagementError` until the outer block ends. Let exceptions
+  propagate to the outermost `atomic()` instead of catching them mid-transaction.
+
+- **Django `TestCase`**. It relies on savepoints to isolate each test, so it
+  does not work here. Use **`TransactionTestCase`** (with `databases =
+  {"default"}`) for database tests.
+
+- **DDL inside `atomic()`** (`can_rollback_ddl = False`). YDB cannot roll back
+  schema changes, so running DDL inside an `atomic()` block raises
+  `TransactionManagementError`. Migrations are applied non-atomically for the
+  same reason.
+
+## Retries and conflicts
+
+YDB uses optimistic concurrency with `SERIALIZABLE` isolation, so transactions
+that touch the same rows concurrently can conflict. The losing transaction is
+aborted with a retryable error, surfaced as `django.db.OperationalError`
+("Transaction locks invalidated").
+
+- **Statements in autocommit** (outside `atomic()`) are retried automatically by
+  the YDB driver on transient/retryable errors — a single statement is its own
+  transaction and is safe to replay.
+- **`atomic()` blocks are not retried automatically.** Neither the driver (it
+  cannot replay a multi-statement interactive transaction) nor Django (which has
+  no built-in transaction retry) retries them. Retrying is the application's
+  responsibility: catch `OperationalError` and re-run the whole block.
+
+```python
+from django.db import OperationalError, transaction
+
+for attempt in range(3):
+    try:
+        with transaction.atomic():
+            ...  # reads and writes
+        break
+    except OperationalError:
+        if attempt == 2:
+            raise
+```

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,6 +50,7 @@ Documentation
    FIELDS
    MIGRATIONS
    OPERATIONS
+   TRANSACTIONS
 
 
 Indices and tables

--- a/tests/transactions/models.py
+++ b/tests/transactions/models.py
@@ -1,0 +1,8 @@
+from django.db import models
+
+
+class TxItem(models.Model):
+    name = models.CharField(max_length=50)
+
+    def __str__(self):
+        return self.name

--- a/tests/transactions/test_transactions.py
+++ b/tests/transactions/test_transactions.py
@@ -1,0 +1,63 @@
+from django.db import connection
+from django.db import transaction
+from django.db.transaction import TransactionManagementError
+from django.test import TransactionTestCase
+
+from .models import TxItem
+
+
+class TestAtomic(TransactionTestCase):
+    databases = {"default"}
+
+    def test_commit(self):
+        with transaction.atomic():
+            TxItem.objects.create(name="a")
+        self.assertEqual(TxItem.objects.filter(name="a").count(), 1)
+
+    def test_rollback_on_exception(self):
+        with self.assertRaises(ValueError), transaction.atomic():
+            TxItem.objects.create(name="b")
+            raise ValueError
+        self.assertEqual(TxItem.objects.filter(name="b").count(), 0)
+
+    def test_set_rollback(self):
+        with transaction.atomic():
+            TxItem.objects.create(name="c")
+            transaction.set_rollback(True)
+        self.assertEqual(TxItem.objects.filter(name="c").count(), 0)
+
+    def test_nested_atomic_outer_rollback(self):
+        with self.assertRaises(ValueError), transaction.atomic():
+            TxItem.objects.create(name="outer")
+            with transaction.atomic():
+                TxItem.objects.create(name="inner")
+            raise ValueError
+        self.assertEqual(TxItem.objects.count(), 0)
+
+    def test_connection_usable_after_error(self):
+        with self.assertRaises(ValueError), transaction.atomic():
+            TxItem.objects.create(name="d")
+            raise ValueError
+        self.assertEqual(TxItem.objects.filter(name="d").count(), 0)
+        TxItem.objects.create(name="ok")
+        self.assertEqual(TxItem.objects.filter(name="ok").count(), 1)
+
+    def test_inner_atomic_caught_exception_breaks_transaction(self):
+        # No savepoints: a caught exception inside a nested atomic marks the
+        # whole transaction for rollback, so further queries are rejected.
+        with self.assertRaises(TransactionManagementError), transaction.atomic():
+            try:
+                with transaction.atomic():
+                    TxItem.objects.create(name="x")
+                    raise ValueError  # noqa: TRY301
+            except ValueError:
+                pass
+            TxItem.objects.count()
+        self.assertEqual(TxItem.objects.count(), 0)
+
+    def test_ddl_inside_atomic_raises(self):
+        # YDB cannot roll back DDL (can_rollback_ddl=False), so schema changes
+        # inside an atomic block are rejected.
+        with self.assertRaises(TransactionManagementError), transaction.atomic(), \
+                connection.schema_editor() as editor:
+            editor.create_model(TxItem)

--- a/ydb_backend/backend/base.py
+++ b/ydb_backend/backend/base.py
@@ -244,7 +244,13 @@ class DatabaseWrapper(BaseDatabaseWrapper):
 
     def _set_autocommit(self, autocommit):
         """
-        Backend-specific implementation to enable or disable autocommit.
+        Enable or disable autocommit.
+
+        Disabling autocommit (entering ``transaction.atomic()``) opens an
+        interactive YDB transaction; Django then drives ``commit()`` /
+        ``rollback()`` on exit. Re-enabling it returns to per-statement
+        autocommit. YDB has no savepoints, so nested atomic blocks are not
+        isolated (see ``uses_savepoints = False``).
         """
         conn = self.connection
         if autocommit:


### PR DESCRIPTION
Closes #36.

`transaction.atomic()` already worked through `_set_autocommit`'s interactive YDB transaction (the issue's "empty `_set_autocommit`" is out of date). This pins the behaviour with tests and documents the contract.

## Contract
- **`atomic()`** commits on clean exit, rolls back on exception or `transaction.set_rollback(True)`; the connection stays usable afterwards.
- **No savepoints** (`uses_savepoints = False`): YDB has none, so nested `atomic()` blocks are not isolated — a caught exception *inside* a nested block poisons the whole transaction (further queries raise `TransactionManagementError`). Django **`TestCase` is unsupported**; use `TransactionTestCase`.
- **No DDL inside `atomic()`** (`can_rollback_ddl = False`); migrations run non-atomically.
- **Retries:** autocommit statements are retried by the YDB driver on transient errors; `atomic()` conflicts (optimistic `SERIALIZABLE`, "Transaction locks invalidated") surface as `django.db.OperationalError` and must be retried by the application — neither the driver nor Django retries a multi-statement transaction.

Adds `tests/transactions/` and `docs/TRANSACTIONS.md`; the feature flags already matched this behaviour.