### PR TITLE
Implement native YDB UPSERT INTO for YDBManager

### DIFF
--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -215,20 +215,19 @@ Covered by `tests/django_contrib/test_smoke.py`; see [CONTRIB.md](CONTRIB.md).
 
 ## UPSERT
 
-**Contract decision: the supported public UPSERT is the native YDB
-`UPSERT INTO`** — atomic, race-free, keyed on the primary key. The user-facing
-API is `YDBManager`: set `objects = YDBManager()` on the model, then call
+The supported public UPSERT is the native YDB `UPSERT INTO` — a single atomic,
+race-free statement keyed on the primary key. The user-facing API is
+`YDBManager`: set `objects = YDBManager()` on the model, then call
 `Model.objects.upsert(obj)` / `bulk_upsert(objs)` (each accepts a model instance
 or a dict and returns the persisted instances).
 
-Wiring the native path is **release-blocking** and tracked in #46; the
-docs/examples in [OPERATIONS.md](OPERATIONS.md) follow in #47. **Until #46
-lands, the emulated path below is what actually ships.**
+| Aspect | Status | Notes |
+|--------|:------:|-------|
+| `YDBManager.upsert()` / `bulk_upsert()` | ✅ | Native `UPSERT INTO` via `SQLUpsertCompiler`. One statement (rows passed as a `List<Struct>` parameter), so no read-modify-write and no race window. Covered by `tests/compiler/test_upsert.py`. |
+| Conflict target | ✅ (PK only) | UPSERT is keyed on the primary key. `conflict_target` defaults to the PK; passing anything else raises `NotSupportedError`. |
+| `update_fields` (write a subset of columns) | 🟡 | Restricts the written columns; columns left out are preserved on existing rows. YDB requires **every NOT NULL column** to be present, so `update_fields` may only drop nullable columns — omitting a NOT NULL column raises `NotSupportedError`. |
 
-| Path | Status | Notes |
-|------|:------:|-------|
-| Native `UPSERT INTO` | ❌ today → ✅ target (#46) | The chosen supported path. `SQLUpsertCompiler` already emits `UPSERT INTO`, but the manager does not route to it yet (it gates on an undefined `can_return_upserted_objects` flag), so it is not reachable today. #46 wires it up and defines return behavior. Atomic and race-free once wired. |
-| `YDBManager` emulated path | 🟡 | What ships until #46: SELECT-then-INSERT/UPDATE inside `transaction.atomic()`, updating only changed fields. Default conflict target is `unique_together[0]` if set, else the PK. **Not race-free** (YDB enforces no uniqueness on non-PK targets) — reliable for single-writer use. Covered by `tests/compiler/test_upsert.py`. |
+> The docs/examples in [OPERATIONS.md](OPERATIONS.md) are rewritten separately in #47.
 
 ---
 
@@ -260,7 +259,7 @@ Proposed split for the first non-beta (issue #51 tracks readiness):
 - README/docs support claims match tested behavior (#50).
 - Version target named and packaging metadata aligned (Python `>=3.10`, Django `>=4.2,<7.0`). ✅
 - Transaction contract documented (#36, done).
-- Native `UPSERT INTO` wired up as the supported upsert path (#46).
+- Native `UPSERT INTO` wired up as the supported upsert path (#46). ✅
 - Pattern/exact lookup escaping returns the correct rows (#75) — currently
   produces **silently wrong results** for backslash/special characters, so it
   must be fixed before non-beta.

--- a/tests/compiler/models.py
+++ b/tests/compiler/models.py
@@ -128,3 +128,15 @@ class EventRecord(models.Model):
 
     def __str__(self):
         return f"{self.name} {self.occurred_at}"
+
+
+class InventoryItem(models.Model):
+    sku = models.CharField(max_length=20, primary_key=True)
+    name = models.CharField(max_length=100)
+    reorder_level = models.IntegerField(null=True)
+    quantity = models.IntegerField()
+
+    objects = YDBManager()
+
+    def __str__(self):
+        return f"{self.sku} {self.name} {self.reorder_level} {self.quantity}"

--- a/tests/compiler/test_upsert.py
+++ b/tests/compiler/test_upsert.py
@@ -1,5 +1,7 @@
+from django.db import NotSupportedError
 from django.test import TransactionTestCase
 
+from .models import InventoryItem
 from .models import NFTToken
 
 
@@ -237,3 +239,51 @@ class NFTTokenUpsertTest(TransactionTestCase):
         self.assertEqual(results[1].token_id, "202")
         self.assertEqual(results[2].token_id, "404")
         self.assertEqual(results[3].token_id, "303")
+
+    def test_upsert_returns_instance(self):
+        result = NFTToken.objects.upsert(self.token1_data)
+        self.assertIsInstance(result, NFTToken)
+        self.assertEqual(result.token_id, "12345")
+
+    def test_empty_bulk_upsert_returns_empty(self):
+        self.assertEqual(NFTToken.objects.bulk_upsert([]), [])
+        self.assertEqual(NFTToken.objects.count(), 0)
+
+    def test_explicit_conflict_target_on_pk_is_ok(self):
+        NFTToken.objects.upsert(self.token1_data, conflict_target="token_id")
+        self.assertEqual(NFTToken.objects.count(), 1)
+        self.assertEqual(NFTToken.objects.get(token_id="12345").owner, "0xAlice123")
+
+    def test_unsupported_conflict_target_raises(self):
+        # YDB UPSERT is keyed on the primary key; a non-PK target must fail
+        # clearly rather than silently upserting by PK.
+        with self.assertRaises(NotSupportedError):
+            NFTToken.objects.upsert(self.token1_data, conflict_target="owner")
+
+
+class InventoryUpsertTest(TransactionTestCase):
+    def test_update_fields_skips_nullable_column(self):
+        InventoryItem.objects.upsert(
+            {"sku": "A1", "name": "Widget", "reorder_level": 3, "quantity": 5}
+        )
+
+        # Re-upsert writing only the NOT NULL columns, dropping the nullable
+        # reorder_level. YDB UPSERT preserves columns left out of the statement.
+        InventoryItem.objects.upsert(
+            {"sku": "A1", "name": "Widget v2", "quantity": 9},
+            update_fields=["name", "quantity"],
+        )
+
+        item = InventoryItem.objects.get(sku="A1")
+        self.assertEqual(item.name, "Widget v2")
+        self.assertEqual(item.quantity, 9)
+        self.assertEqual(item.reorder_level, 3)
+
+    def test_update_fields_omitting_not_null_column_raises(self):
+        # quantity is NOT NULL and YDB UPSERT requires it, so omitting it must
+        # fail clearly rather than leaking the raw YDB error.
+        with self.assertRaises(NotSupportedError):
+            InventoryItem.objects.upsert(
+                {"sku": "A2", "name": "X", "quantity": 1},
+                update_fields=["name"],
+            )

--- a/ydb_backend/backend/operations.py
+++ b/ydb_backend/backend/operations.py
@@ -451,6 +451,9 @@ class DatabaseOperations(BaseDatabaseOperations):
         Savepoint operations are not supported in YDB - empty stub for Django
         """
 
-    @staticmethod
-    def upsert_statement():
+    def upsert_statement(self, on_conflict=None):
+        # YDB's UPSERT INTO inserts missing rows and overwrites the listed
+        # columns of existing rows, keyed on the primary key. on_conflict is
+        # accepted for parity with insert_statement(); YDB has no conflict
+        # clause to emit.
         return "UPSERT INTO"

--- a/ydb_backend/models/manager.py
+++ b/ydb_backend/models/manager.py
@@ -1,161 +1,112 @@
-import logging
-
+from django.db import NotSupportedError
 from django.db import models
-from django.db import transaction
-from django.db.models import QuerySet
-from django.db.utils import DatabaseError
-from django.db.utils import IntegrityError
+from django.db import router
 
-logger = logging.getLogger("django_ydb_backend.models.manager")
+from .sql.query import UpsertQuery
 
 
 class YDBManager(models.Manager):
-    def get_queryset(self):
-        return UpsertQuerySet(self.model, using=self._db)
+    """Default manager that adds native YDB ``UPSERT INTO`` to a model.
+
+    Set ``objects = YDBManager()`` on a model and call ``upsert()`` /
+    ``bulk_upsert()``. Rows are matched by primary key: an existing row has its
+    listed columns overwritten and a missing row is inserted, in a single
+    atomic statement (no read-modify-write, so no race window).
+    """
 
     def upsert(self, obj, conflict_target=None, update_fields=None):
-        """
-        UPSERT single object (model instance or dict)
-        Returns the upserted model instance
-        """
-        if isinstance(obj, dict):
-            obj = self.model(**obj)
-
-        results = self.bulk_upsert(
+        """UPSERT a single model instance or dict; return the instance."""
+        return self.bulk_upsert(
             [obj],
             conflict_target=conflict_target,
-            update_fields=update_fields
-        )
-
-        return results[0] if results else obj
+            update_fields=update_fields,
+        )[0]
 
     def bulk_upsert(self, objs, conflict_target=None, update_fields=None):
-        """
-        Bulk UPSERT objects (can mix instances and dicts)
-        Returns list of upserted model instances
+        """UPSERT model instances and/or dicts; return the instances.
+
+        ``conflict_target`` is accepted for API symmetry but must name the
+        primary key (YDB UPSERT is PK-keyed); anything else raises
+        ``NotSupportedError``. ``update_fields`` restricts which non-key columns
+        are written (all concrete fields by default). Columns left out are
+        preserved on existing rows; omitting a NOT NULL column without a default
+        will fail when a brand-new row has to be inserted.
         """
         if not objs:
             return []
 
-        # Convert all dicts to model instances
         objs = [
             self.model(**obj) if isinstance(obj, dict) else obj
             for obj in objs
         ]
+        self._check_conflict_target(conflict_target)
+        fields = self._upsert_fields(update_fields)
 
-        conflict_target = conflict_target or self._get_default_conflict_target()
-        update_fields = (
-                update_fields
-                or self._get_default_update_fields(conflict_target)
+        query = UpsertQuery(self.model)
+        query.insert_values(fields, objs)
+
+        opts = self.model._meta
+        auto_pk = isinstance(
+            opts.pk,
+            models.AutoField | models.SmallAutoField | models.BigAutoField,
+        )
+        using = self._db or router.db_for_write(self.model)
+        compiler = query.get_compiler(using=using)
+        rows = compiler.execute_sql(
+            returning_fields=[opts.pk] if auto_pk else None
+        )
+        # Echo back database-generated keys for auto-pk models; for a supplied
+        # primary key the value is already on the instance.
+        if auto_pk and rows:
+            for obj, row in zip(objs, rows, strict=False):
+                setattr(obj, opts.pk.attname, row[0])
+        return objs
+
+    def _check_conflict_target(self, conflict_target):
+        if conflict_target is None:
+            return
+        pk = self.model._meta.pk
+        targets = (
+            [conflict_target]
+            if isinstance(conflict_target, str)
+            else list(conflict_target)
+        )
+        if targets not in ([pk.name], [pk.attname]):
+            msg = (
+                "YDB UPSERT is keyed on the primary key; conflict_target "
+                f"{conflict_target!r} is not supported. Use the primary key "
+                f"({pk.name!r}) or omit conflict_target."
+            )
+            raise NotSupportedError(msg)
+
+    def _upsert_fields(self, update_fields):
+        opts = self.model._meta
+        if update_fields is None:
+            return list(opts.local_concrete_fields)
+
+        wanted = set(update_fields)
+        pk = opts.pk
+        selected = [pk]
+        selected.extend(
+            f
+            for f in opts.local_concrete_fields
+            if f is not pk and (f.name in wanted or f.attname in wanted)
         )
 
-        # Try native UPSERT first
-        native_upsert_supported = (
-                hasattr(
-                    self._db,
-                    "features"
-                ) and
-                getattr(
-                    self._db.features,
-                    "can_return_upserted_objects",
-                    False
-                )
-        )
-
-        if native_upsert_supported:
-            try:
-                return self.get_queryset().bulk_upsert(
-                    objs, conflict_target, update_fields
-                )
-            except DatabaseError as e:
-                logger.debug("Database error during native UPSERT: %s", e)
-            except NotImplementedError as e:
-                logger.debug("UPSERT not implemented: %s", e)
-
-        # Fallback to optimized emulated UPSERT
-        return self._optimized_emulated_upsert(objs, conflict_target, update_fields)
-
-    def _get_default_conflict_target(self):
-        """Get default conflict target from model meta"""
-        if self.model._meta.unique_together:
-            return list(self.model._meta.unique_together[0])
-        return [self.model._meta.pk.name]
-
-    def _get_default_update_fields(self, conflict_target):
-        """Get default fields to update (all except PK and conflict target)"""
-        return [
-            f.name for f in self.model._meta.fields
-            if f.name not in conflict_target and not f.primary_key
+        # YDB UPSERT requires every NOT NULL column to be present in the
+        # statement, even for rows that already exist, so update_fields may
+        # only drop nullable columns. Fail clearly instead of leaking YDB's
+        # "missing not null column" error.
+        selected_set = set(selected)
+        missing = [
+            f.name
+            for f in opts.local_concrete_fields
+            if f not in selected_set and not f.null
         ]
-
-    def _optimized_emulated_upsert(self, objs, conflict_target, update_fields):
-        """
-        Optimized emulated UPSERT that:
-        1. Never creates duplicates
-        2. Only updates changed fields
-        3. Returns persisted objects
-        """
-        persisted_objs = []
-
-        with transaction.atomic(using=self.db):
-            for obj in objs:
-                # Build filter for existing object
-                filter_kwargs = {
-                    field: getattr(obj, field)
-                    for field in conflict_target
-                }
-
-                # Try to get existing object
-                existing = self.filter(**filter_kwargs).first()
-
-                if existing:
-                    # UPDATE existing record if needed
-                    needs_update = False
-                    for field in update_fields:
-                        new_value = getattr(obj, field)
-                        if getattr(existing, field) != new_value:
-                            setattr(existing, field, new_value)
-                            needs_update = True
-
-                    if needs_update:
-                        existing.save(update_fields=update_fields)
-                    persisted_objs.append(existing)
-                else:
-                    # INSERT new record
-                    try:
-                        obj.save(force_insert=True)
-                        persisted_objs.append(obj)
-                    except IntegrityError:
-                        # Handle race condition
-                        existing = self.filter(**filter_kwargs).first()
-                        if not existing:
-                            raise
-                        persisted_objs.append(existing)
-
-        return persisted_objs
-
-
-class UpsertQuerySet(QuerySet):
-    def bulk_upsert(self, objs, conflict_target, update_fields):
-        """
-        Native UPSERT implementation using compiler
-        """
-        # Convert dicts to model instances if needed
-        objs = [
-            self.model(**obj) if isinstance(obj, dict) else obj
-            for obj in objs
-        ]
-
-        if not hasattr(self.query, "compiler"):
-            raise NotImplementedError("This backend doesn't support native UPSERT")
-
-        compiler = self.query.get_compiler(self.db)
-        if not hasattr(compiler, "execute_upsert"):
-            raise NotImplementedError("Compiler doesn't support execute_upsert")
-
-        return compiler.execute_upsert(
-            objs=objs,
-            conflict_target=conflict_target,
-            update_fields=update_fields,
-            returning=True  # Ensure we get results back
-        )
+        if missing:
+            msg = (
+                f"update_fields omits NOT NULL column(s) {missing!r}, which "
+                "YDB UPSERT requires. Include them, or make the fields nullable."
+            )
+            raise NotSupportedError(msg)
+        return selected

--- a/ydb_backend/models/sql/query.py
+++ b/ydb_backend/models/sql/query.py
@@ -1,0 +1,14 @@
+from django.db.models.sql import InsertQuery
+
+
+class UpsertQuery(InsertQuery):
+    """An INSERT-shaped query compiled with YDB's ``UPSERT INTO`` statement.
+
+    YDB ``UPSERT INTO`` is keyed on the primary key: existing rows have their
+    listed columns overwritten and missing rows are inserted, in a single
+    atomic statement. It reuses Django's insert machinery (``insert_values``)
+    and is compiled by ``SQLUpsertCompiler``, which is resolved by name from
+    the ``compiler`` attribute through the backend's ``compiler_module``.
+    """
+
+    compiler = "SQLUpsertCompiler"


### PR DESCRIPTION
Implements the native UPSERT contract ratified in the support contract (#30): `YDBManager.upsert()` / `bulk_upsert()` now run YDB's native `UPSERT INTO` instead of the previous emulated SELECT-then-INSERT/UPDATE.

## What changed
- **`UpsertQuery`** (new `ydb_backend/models/sql/query.py`): an `InsertQuery` compiled by `SQLUpsertCompiler`, so UPSERT reuses Django's insert machinery (`insert_values`) the same way `bulk_create` does.
- **`YDBManager`** rewritten to build an `UpsertQuery` and execute a single atomic `UPSERT INTO` statement (rows passed as a `List<Struct>` parameter). No read-modify-write, so no race window. Returns the persisted instances. Removed the unreachable emulated path, the undefined `can_return_upserted_objects` gate, and `UpsertQuerySet`.
- **`Ops.upsert_statement(on_conflict=None)`**: fixed the signature so the compiler can call it (it previously took no arguments and raised).

## Behavior / contract
- Keyed on the **primary key**. `conflict_target` defaults to the PK; any other target raises `NotSupportedError`.
- `update_fields` restricts the written columns (others are preserved on existing rows). YDB `UPSERT INTO` requires **every NOT NULL column** to be present, so `update_fields` may only drop nullable columns — omitting a NOT NULL column raises a clear `NotSupportedError` instead of leaking YDB's "missing not null column".

`docs/SUPPORT.md` UPSERT section updated (native path is now ✅). The OPERATIONS.md examples are rewritten separately in #47.

Closes #46
