### PR TITLE
Rewrite UPSERT docs and examples for the native API

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -2,8 +2,7 @@ Operations
 ===
 
 > See the [support contract](SUPPORT.md#upsert) for the UPSERT support level and
-> the [ORM query features](SUPPORT.md#orm-query-features) matrix. The UPSERT
-> examples below are being revised (issue #47).
+> the [ORM query features](SUPPORT.md#orm-query-features) matrix.
 
 The operations implement the Django ORM query compilation system in a YDB-specific syntax, taking into account the features of this distributed database.
 
@@ -28,55 +27,106 @@ annotations, aggregate (`HAVING`) filters and non-correlated subqueries.
   `OuterRef` reference the outer table from inside the subquery, which YDB
   cannot resolve. Non-correlated subqueries work.
 
-## UPSERT Operation
-UPSERT (which stands for UPDATE or INSERT) updates or inserts multiple rows to a table based on a comparison by the primary key.
-Missing rows are added. For the existing rows, the values of the specified columns are updated, but the values of the other columns are preserved.
+## UPSERT
 
-To use the pert method when creating a model, specify objects = YDBManager():
+UPSERT (UPDATE or INSERT) writes rows keyed on the **primary key**: a missing
+row is inserted, and an existing row has the written columns overwritten while
+its other columns are preserved. The backend uses YDB's native `UPSERT INTO`,
+which runs as a **single atomic statement** — there is no read-modify-write
+step, so concurrent upserts of the same key cannot create duplicates.
+
+### Manager setup
+
+UPSERT is provided by `YDBManager`. Set it as the model's manager:
+
 ```python
-  class NFTToken(models.Model):
-      contract_address = models.CharField(max_length=42)
-      token_id = models.CharField(max_length=78, primary_key=True)
-      owner = models.CharField(max_length=42)
-      metadata_url = models.CharField(max_length=256)
-      last_price = models.FloatField()
-  
-      objects = YDBManager()
-  
-      def __str__(self):
-          return (
-              f"{self.contract_address} "
-              f"{self.token_id} "
-              f"{self.owner} "
-              f"{self.metadata_url} "
-              f"{self.last_price}"
-          )
+from django.db import models
+from ydb_backend.models.manager import YDBManager
+
+
+class NFTToken(models.Model):
+    contract_address = models.CharField(max_length=42)
+    token_id = models.CharField(max_length=78, primary_key=True)
+    owner = models.CharField(max_length=42)
+    metadata_url = models.CharField(max_length=256)
+    last_price = models.FloatField()
+
+    objects = YDBManager()
 ```
-An examples of using upsert:
+
+### upsert() and bulk_upsert()
+
+Both accept a model instance or a dict (`bulk_upsert` accepts a list, and may
+mix the two) and return the persisted instances:
+
 ```python
-token1_data = {
+# Insert: the row does not exist yet.
+NFTToken.objects.upsert({
     "contract_address": "0x1a2b3c4d5e",
     "token_id": "12345",
     "owner": "0xAlice123",
     "metadata_url": "ipfs://QmXyZ123",
-    "last_price": 1.5
-}
-token2_data = {
-    "contract_address": "0x1a2b3c4d5d",
-    "token_id": "12346",
-    "owner": "0xBob450",
-    "metadata_url": "ipfs://QmXyZ456r04",
-    "last_price": 5.7
-}
-update_data = {
-    "token_id": "12345",
+    "last_price": 1.5,
+})
+
+# Update: same primary key — the listed columns are overwritten.
+NFTToken.objects.upsert({
     "contract_address": "0x1a2b3c4d5e",
+    "token_id": "12345",
     "owner": "0xBob456",
+    "metadata_url": "ipfs://QmXyZ456",
     "last_price": 2.5,
-    "metadata_url": "ipfs://QmXyZ456"
-}
-NFTToken.objects.create(token1_data)
-NFTToken.objects.create(token2_data)
-NFTToken.objects.upsert(update_data)
-NFTToken.objects.create(token2_data)
+})
+
+# Bulk: one statement upserts every row.
+tokens = NFTToken.objects.bulk_upsert([
+    {"contract_address": "0x11", "token_id": "100", "owner": "0xA",
+     "metadata_url": "ipfs://a", "last_price": 10.0},
+    NFTToken(contract_address="0x22", token_id="200", owner="0xB",
+             metadata_url="ipfs://b", last_price=20.0),
+])
 ```
+
+### Conflict target
+
+UPSERT is always keyed on the primary key. `conflict_target` may be omitted (it
+defaults to the primary key) or set to the primary key explicitly; any other
+target raises `NotSupportedError`, because YDB has no unique constraints to
+match on:
+
+```python
+NFTToken.objects.upsert(data, conflict_target="token_id")  # ok — the PK
+NFTToken.objects.upsert(data, conflict_target="owner")     # NotSupportedError
+```
+
+### Writing a subset of columns
+
+`update_fields` restricts which columns are written; columns left out are
+preserved on existing rows. YDB's `UPSERT INTO` requires **every NOT NULL
+column** to be present, so `update_fields` may only drop nullable columns —
+omitting a NOT NULL column raises `NotSupportedError`.
+
+```python
+class InventoryItem(models.Model):
+    sku = models.CharField(max_length=20, primary_key=True)
+    name = models.CharField(max_length=100)          # NOT NULL
+    reorder_level = models.IntegerField(null=True)   # nullable
+    quantity = models.IntegerField()                 # NOT NULL
+
+    objects = YDBManager()
+
+
+# Writes name + quantity; the nullable reorder_level is left untouched.
+InventoryItem.objects.upsert(
+    {"sku": "A1", "name": "Widget", "quantity": 9},
+    update_fields=["name", "quantity"],
+)
+
+# Raises NotSupportedError: omits the NOT NULL column `quantity`.
+InventoryItem.objects.upsert(
+    {"sku": "A1", "name": "Widget"},
+    update_fields=["name"],
+)
+```
+
+The behavior above is covered by `tests/compiler/test_upsert.py`.


### PR DESCRIPTION
Rewrites the UPSERT section of `docs/OPERATIONS.md` to match the native `UPSERT INTO` implementation (#46).

- Fixes the broken examples (`create(dict)` passed a dict positionally) so they run as written: `upsert()` / `bulk_upsert()` / `create(**dict)`.
- Documents the manager setup, the atomic PK-keyed semantics (single statement, no race window), `conflict_target` (PK only, else `NotSupportedError`), and `update_fields` (YDB requires every NOT NULL column, so only nullable columns may be dropped).
- Links to `tests/compiler/test_upsert.py` and the support contract.

Closes #47
