### PR TITLE
Fix LIKE/exact lookup escaping for YQL

### DIFF
--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -169,7 +169,7 @@ operation: it either raises `NotSupportedError` or skips with a warning.
 |---------|:------:|-------|
 | CRUD (`create`/`get`/`filter`/`update`/`delete`) | ✅ | |
 | Most field lookups | ✅ | `exact`, `in`, ranges, `icontains`, date-extract (`week_day`/`week`/`quarter`/...), etc. |
-| Backslash / special-char escaping in pattern & exact lookups | ❌ | Incorrect results (issue #75). |
+| Backslash / `%` / `_` escaping in pattern & exact lookups | ✅ | Escaped correctly via `ESCAPE '~'` (issue #75). `Substr()` on a text column is still unsupported (#87). |
 | Coercing lookups (`int`-as-`str`, `date`-as-`str`), regex on NULL/non-string | ❌ | Raise during parameter handling. |
 | Correlated subqueries (`Exists`/`Subquery`/`OuterRef` as LHS) | ❌ | YDB cannot resolve the outer reference (issue #77). Non-correlated subqueries work. |
 | Aggregation / annotation | 🟡 | GROUP BY validation fixed (#76); tail remains: `ORDER BY` aggregated values, `GROUP BY` constant, `PI()`/`Random()`/`CURRENT_TIMESTAMP` (issue #80). |
@@ -260,9 +260,8 @@ Proposed split for the first non-beta (issue #51 tracks readiness):
 - Version target named and packaging metadata aligned (Python `>=3.10`, Django `>=4.2,<7.0`). ✅
 - Transaction contract documented (#36, done).
 - Native `UPSERT INTO` wired up as the supported upsert path (#46). ✅
-- Pattern/exact lookup escaping returns the correct rows (#75) — currently
-  produces **silently wrong results** for backslash/special characters, so it
-  must be fixed before non-beta.
+- Pattern/exact lookup escaping returns the correct rows (#75). ✅ Fixed —
+  backslash, `%` and `_` are escaped with `ESCAPE '~'`.
 
 **Non-blocking (documented limitations, can ship as known gaps):**
 - Naive datetime shift under `USE_TZ=False` (#78) — production default unaffected.

--- a/tests/compiler/test_pattern_escaping.py
+++ b/tests/compiler/test_pattern_escaping.py
@@ -1,0 +1,83 @@
+from django.db.models import F
+from django.test import TransactionTestCase
+
+from .models import Book
+
+
+class PatternEscapingTest(TransactionTestCase):
+    """`%`, `_` and `\\` in a lookup value are matched literally (issue #75)."""
+
+    def setUp(self):
+        self.under = Book.objects.create(
+            isbn="1", title="Article_ with underscore", author="x", price=1
+        )
+        self.pct = Book.objects.create(
+            isbn="2", title="Article% with percent", author="x", price=1
+        )
+        self.backslash = Book.objects.create(
+            isbn="3", title="Article with \\ backslash", author="x", price=1
+        )
+        self.plain = Book.objects.create(
+            isbn="4", title="Article plain", author="x", price=1
+        )
+
+    def test_startswith_matches_literal_underscore(self):
+        self.assertCountEqual(
+            Book.objects.filter(title__startswith="Article_"),
+            [self.under],
+        )
+
+    def test_startswith_matches_literal_percent(self):
+        self.assertCountEqual(
+            Book.objects.filter(title__startswith="Article%"),
+            [self.pct],
+        )
+
+    def test_contains_matches_literal_backslash(self):
+        self.assertCountEqual(
+            Book.objects.filter(title__contains="\\"),
+            [self.backslash],
+        )
+
+    def test_startswith_without_specials_matches_all(self):
+        self.assertCountEqual(
+            Book.objects.filter(title__startswith="Article"),
+            [self.under, self.pct, self.backslash, self.plain],
+        )
+
+    def test_icontains_matches_literal_underscore(self):
+        self.assertCountEqual(
+            Book.objects.filter(title__icontains="article_"),
+            [self.under],
+        )
+
+
+class PatternLookupExpressionTest(TransactionTestCase):
+    """Pattern lookups with an expression (column) RHS use pattern_ops/pattern_esc."""
+
+    def test_contains_startswith_endswith_with_column(self):
+        a = Book.objects.create(
+            isbn="20", title="hello world", author="hello", price=1
+        )
+        b = Book.objects.create(
+            isbn="21", title="say hello", author="hello", price=1
+        )
+        c = Book.objects.create(
+            isbn="22", title="well hello there", author="hello", price=1
+        )
+        self.assertCountEqual(Book.objects.filter(title__startswith=F("author")), [a])
+        self.assertCountEqual(Book.objects.filter(title__endswith=F("author")), [b])
+        self.assertCountEqual(
+            Book.objects.filter(title__contains=F("author")), [a, b, c]
+        )
+
+    def test_column_expression_escapes_special_chars(self):
+        # The author value carries a literal '%'; it must be escaped on the
+        # database side (pattern_esc), not treated as a LIKE wildcard.
+        literal = Book.objects.create(
+            isbn="23", title="10% off", author="10%", price=1
+        )
+        Book.objects.create(isbn="24", title="10X off", author="10%", price=1)
+        self.assertCountEqual(
+            Book.objects.filter(title__startswith=F("author")), [literal]
+        )

--- a/ydb_backend/backend/base.py
+++ b/ydb_backend/backend/base.py
@@ -77,19 +77,22 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         "BinaryField": "String",
     }
 
+    # YDB's LIKE/ILIKE use '~' as the ESCAPE character: YQL rejects the SQL
+    # default '\' (and '%'/'_') in the ESCAPE clause. The escaped values are
+    # produced by DatabaseOperations.prep_for_like_query.
     operators = {
         "exact": "= %s",
         "iexact": "REGEXP '(?i)(' || %s || ')$'",
-        "contains": "LIKE %s",
-        "icontains": "ILIKE %s",
+        "contains": "LIKE %s ESCAPE '~'",
+        "icontains": "ILIKE %s ESCAPE '~'",
         "gt": "> %s",
         "gte": ">= %s",
         "lt": "< %s",
         "lte": "<= %s",
-        "startswith": "LIKE %s",
-        "endswith": "LIKE %s",
-        "istartswith": "ILIKE %s",
-        "iendswith": "ILIKE %s",
+        "startswith": "LIKE %s ESCAPE '~'",
+        "endswith": "LIKE %s ESCAPE '~'",
+        "istartswith": "ILIKE %s ESCAPE '~'",
+        "iendswith": "ILIKE %s ESCAPE '~'",
         "and": "AND",
         "or": "OR",
         "in": "IN (%s)",
@@ -99,24 +102,30 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         "iregex": "REGEXP '(?i)' || %s",
     }
 
-    # The patterns below are used to generate SQL pattern lookup clauses when
-    # the right-hand side of the lookup isn't a raw string (it might be an expression
-    # or the result of a bilateral transformation).
-    # In those cases, special characters for LIKE operators (e.g. \, *, _) should be
-    # escaped on database side.
-    #
-    # Note: we use str.format() here for readability as '%' is used as a wildcard for
-    # the LIKE operator.
+    # Used when the right-hand side of a pattern lookup is an expression (e.g.
+    # a column reference or a transform such as Substr) rather than a plain
+    # value. Django fills pattern_esc into pattern_ops and the expression into
+    # pattern_esc via str.format(); '%%' survives the final '%'-formatting in
+    # Lookup.as_sql as a single '%' wildcard. YDB has no SQL REPLACE(), so the
+    # special characters ('~', '%', '_') are escaped with String::ReplaceAll,
+    # consistently with prep_for_like_query and ESCAPE '~'.
+    # Unicode::ReplaceAll operates on Utf8 (String::ReplaceAll is String-only
+    # and rejects a Utf8 expression). The Utf8 (``u``) literals keep ``||`` and
+    # the left-hand Utf8 column/expression on the same operand type. A single
+    # ``%`` is used (not the SQL-standard doubled ``%%``): this backend resolves
+    # parameters by name and never ``%``-formats the assembled query, so ``%%``
+    # would reach YDB doubled and break the literal-percent escaping.
     pattern_esc = (
-        r"REPLACE(REPLACE(REPLACE({}, E'\\', E'\\\\'), E'%%', E'\\%%'), E'_', E'\\_')"
+        "Unicode::ReplaceAll(Unicode::ReplaceAll(Unicode::ReplaceAll("
+        "{}, '~'u, '~~'u), '%'u, '~%'u), '_'u, '~_'u)"
     )
     pattern_ops = {
-        "contains": "LIKE '%%%s%%' ESCAPE '\\'",
-        "icontains": "ILIKE '%%%s%%' ESCAPE '\\'",
-        "startswith": "LIKE '%s%%' ESCAPE '\\'",
-        "istartswith": "ILIKE '%s%%' ESCAPE '\\'",
-        "endswith": "LIKE '%%%s' ESCAPE '\\'",
-        "iendswith": "ILIKE '%%%s' ESCAPE '\\'",
+        "contains": "LIKE '%'u || {} || '%'u ESCAPE '~'",
+        "icontains": "ILIKE '%'u || {} || '%'u ESCAPE '~'",
+        "startswith": "LIKE {} || '%'u ESCAPE '~'",
+        "istartswith": "ILIKE {} || '%'u ESCAPE '~'",
+        "endswith": "LIKE '%'u || {} ESCAPE '~'",
+        "iendswith": "ILIKE '%'u || {} ESCAPE '~'",
     }
 
     Database = Database

--- a/ydb_backend/backend/features.py
+++ b/ydb_backend/backend/features.py
@@ -241,9 +241,9 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             "lookup.tests.LookupTests.test_exact_exists",
             "lookup.tests.LookupTests.test_nested_outerref_lhs",
         },
-        "String escaping for backslashes/special characters in pattern and "
-        "exact lookups is incorrect (YQL token recognition error / wrong rows).": {
-            "lookup.tests.LookupTests.test_escaping",
+        "Substr/SUBSTRING is unsupported on Utf8 columns (YQL SUBSTRING expects "
+        "String); see issue #87. Pattern/exact lookup string escaping is "
+        "otherwise fixed (#75).": {
             "lookup.tests.LookupTests.test_pattern_lookups_with_substr",
         },
         "Lookups that coerce a value to a different field type (int-as-str, "

--- a/ydb_backend/backend/operations.py
+++ b/ydb_backend/backend/operations.py
@@ -268,6 +268,16 @@ class DatabaseOperations(BaseDatabaseOperations):
         msg = f"Lookup '{lookup_type}' is not supported."
         raise NotImplementedError(msg)
 
+    def prep_for_like_query(self, x):
+        """Escape LIKE/ILIKE wildcards, using '~' as the ESCAPE character.
+
+        YQL rejects the SQL-default '\\' (and '%'/'_') in the ESCAPE clause, so
+        the backslash-based default cannot be used here. The escape character
+        itself is escaped first; this matches ``ESCAPE '~'`` in
+        ``DatabaseWrapper.operators`` and ``pattern_ops``.
+        """
+        return str(x).replace("~", "~~").replace("%", "~%").replace("_", "~_")
+
     # TODO: try to understand what is the param 'style'.
     def sql_flush_table(self, style, table):
         """


### PR DESCRIPTION
Fixes pattern (`__contains` / `__startswith` / `__endswith` / `i*`) and exact lookup escaping, which produced YQL parse errors (`token recognition error at: '\'`) or silently wrong rows for values containing `\`, `%` or `_` (#75, release-blocking per the support contract).

## Root cause
`DatabaseWrapper.operators` / `pattern_ops` / `pattern_esc` used Postgres/SQLite syntax YQL cannot parse (`ESCAPE '\'`, `E'...'`, SQL `REPLACE`), and the plain-value `LIKE` declared no `ESCAPE` while values were escaped with a backslash that YDB ignored.

## Fix (grounded in YQL behavior verified against a live YDB)
- The ESCAPE character is `~` — YQL's `ESCAPE` clause rejects `\`, `%` and `_`.
- A `prep_for_like_query` override escapes `~`, `%`, `_` for the bound-value path.
- `pattern_ops` / `pattern_esc` are rewritten to valid YQL: `Unicode::ReplaceAll` (YDB has no SQL `REPLACE`, and `String::ReplaceAll` rejects `Utf8`), `||` concatenation, `ILIKE` for case-insensitive lookups, and a single `%` (this backend resolves parameters by name and never `%`-formats the query, so `%%` would reach YDB doubled).

## Tests
- New `tests/compiler/test_pattern_escaping.py`: literal `%` / `_` / `\` matching, plus a column-expression case asserting `%` is escaped rather than treated as a wildcard.
- Full repo suite passes (292 tests).
- Conformance: `lookup.tests.LookupTests.test_escaping` now passes and is removed from `django_test_skips`.

`Substr()` on a text column stays unsupported (YQL `SUBSTRING` expects `String`); filed separately as #87, so `test_pattern_lookups_with_substr` remains skipped with that reason.

Closes #75
