### PR TITLE
CI: run Django's bundled conformance suite on the matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,3 +56,63 @@ jobs:
 
       - name: Run tests
         run: poetry run coverage run tests/runtests.py
+
+  conformance:
+    # Runs Django's own bundled test suite against YDB as a required gate on
+    # every supported Django version. `basic`/`lookup` must pass (gated by
+    # DatabaseFeatures.django_test_skips); a real failure turns the job red
+    # rather than being hidden behind continue-on-error.
+    runs-on: ubuntu-latest
+
+    concurrency:
+      group: conformance-${{ github.ref }}-${{ matrix.python-version }}-${{ matrix.django-version }}
+      cancel-in-progress: true
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - python-version: "3.10"
+            django-version: "4.2"
+          - python-version: "3.12"
+            django-version: "4.2"
+          - python-version: "3.10"
+            django-version: "5.2"
+          - python-version: "3.12"
+            django-version: "5.2"
+          - python-version: "3.12"
+            django-version: "6.0"
+          - python-version: "3.13"
+            django-version: "6.0"
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Install packages
+        run: poetry install
+
+      - name: Override Django version
+        run: poetry run pip install "django~=${{ matrix.django-version }}"
+
+      - name: Cache Django source tree
+        uses: actions/cache@v4
+        with:
+          path: .django-src
+          key: conformance-django-${{ matrix.django-version }}
+
+      - name: Start YDB
+        run: docker compose up -d --wait
+
+      - name: Conformance — basic, lookup
+        run: conformance/run.sh basic lookup

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -103,13 +103,20 @@ jobs:
         run: poetry install
 
       - name: Override Django version
-        run: poetry run pip install "django~=${{ matrix.django-version }}"
+        id: django
+        run: |
+          poetry run pip install "django~=${{ matrix.django-version }}"
+          version="$(poetry run python -c 'import django; print(django.get_version())')"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Cache Django source tree
         uses: actions/cache@v4
         with:
           path: .django-src
-          key: conformance-django-${{ matrix.django-version }}
+          # Key on the exact resolved version (e.g. 6.0.6): caches are immutable
+          # per key, so a minor-version key would go stale after a patch release
+          # and reclone on every run without ever updating.
+          key: conformance-django-${{ steps.django.outputs.version }}
 
       - name: Start YDB
         run: docker compose up -d --wait

--- a/ydb_backend/backend/creation.py
+++ b/ydb_backend/backend/creation.py
@@ -1,6 +1,7 @@
 import os
 from abc import ABC
 
+import django
 import ydb
 from django.conf import settings
 from django.db.backends.base.creation import BaseDatabaseCreation
@@ -77,6 +78,14 @@ class DatabaseCreation(BaseDatabaseCreation, ABC):
         self._old_ydb_table_path_prefix = self.connection.settings_dict.get(
             "OPTIONS", {}
         ).get("ydb_table_path_prefix")
+        # Django 6.0 deprecated the ``serialize`` argument to create_test_db()
+        # (serialization moved to serialize_test_db()); passing it raises
+        # RemovedInDjango70Warning, which the bundled test runner escalates to
+        # an error. Only forward it on versions that still accept it.
+        if django.VERSION >= (6, 0):
+            return super().create_test_db(
+                verbosity=verbosity, autoclobber=autoclobber, keepdb=keepdb
+            )
         return super().create_test_db(verbosity, autoclobber, serialize, keepdb)
 
     def _execute_create_test_db(self, cursor, parameters, keepdb=False):

--- a/ydb_backend/backend/features.py
+++ b/ydb_backend/backend/features.py
@@ -209,15 +209,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     # inert for this project's own test suite because the guarded test apps are
     # not in its INSTALLED_APPS.
     django_test_skips = {
-        "Naive datetimes are converted through the server/Django timezone "
-        "under USE_TZ=False, so values shift instead of round-tripping. "
-        "Microsecond precision is preserved; the timezone handling is the gap.": {
-            "basic.tests.ModelInstanceCreationTests."
-            "test_for_datetimefields_saves_as_much_precision_as_was_given",
-            "basic.tests.ModelTest.test_microsecond_precision",
-            "basic.tests.ModelRefreshTests.test_refresh",
-            "basic.tests.ModelRefreshTests.test_refresh_unsaved",
-        },
         "Saving a model whose primary key has a database default issues a "
         "different number of queries on YDB (INSERT ... RETURNING).": {
             "basic.tests.ModelInstanceCreationTests."

--- a/ydb_backend/backend/operations.py
+++ b/ydb_backend/backend/operations.py
@@ -2,6 +2,19 @@ import datetime
 import json
 
 from django.db.backends.base.operations import BaseDatabaseOperations
+from django.db.models.functions import Now
+
+
+def _now_as_ydb(self, compiler, connection, **extra_context):
+    # YQL has no CURRENT_TIMESTAMP literal (Now's default template); use the
+    # CurrentUtcTimestamp() built-in. Dispatched via Func.as_<vendor>, so this
+    # only affects the YDB backend.
+    return self.as_sql(
+        compiler, connection, template="CurrentUtcTimestamp()", **extra_context
+    )
+
+
+Now.as_ydb = _now_as_ydb
 
 DATE_PARAMS_EXTRACT = [
     "year",

--- a/ydb_backend/models/sql/compiler.py
+++ b/ydb_backend/models/sql/compiler.py
@@ -150,14 +150,29 @@ _TEMPORAL_FIELD_TYPES = frozenset(
 )
 
 
+# Deliberately naive: used to map a naive (USE_TZ=False) datetime to epoch
+# microseconds as if it were UTC.
+_EPOCH = datetime(1970, 1, 1)  # noqa: DTZ001
+
+
 def _datetime_to_epoch_us(value):
     """
     Return a datetime as epoch microseconds for binding to a YDB Timestamp.
 
-    ``round`` keeps full microsecond precision (``int(value.timestamp())`` would
-    truncate to whole seconds). The value may be negative (before 1970): the
-    column is a signed Timestamp64, which accepts pre-epoch instants.
+    A naive datetime (``USE_TZ = False``) is treated as UTC so it round-trips
+    unchanged, instead of shifting by the system local timezone that
+    ``datetime.timestamp()`` applies to naive values. The arithmetic is exact
+    (timedelta components), keeping full microsecond precision. The value may be
+    negative (before 1970): the column is a signed Timestamp64, which accepts
+    pre-epoch instants.
     """
+    if value.tzinfo is None:
+        delta = value - _EPOCH
+        return (
+            delta.days * 86_400_000_000
+            + delta.seconds * 1_000_000
+            + delta.microseconds
+        )
     return int(round(value.timestamp() * 1_000_000))
 
 
@@ -569,36 +584,75 @@ class SQLCompiler(_ParamTypingMixin, SQLCompiler):
 
 
 class BaseSQLWriteCompiler(compiler.SQLInsertCompiler):
-    def _prepare_sql_statement(self, returning_columns=None):
-        qn = self.connection.ops.quote_name
+    def _split_fields(self):
+        # Separate the insert fields into plain-value fields, passed as the
+        # ``$in_`` List<Struct> parameter, and expression fields such as Now(),
+        # whose SQL is emitted inline in the SELECT. Returns
+        # (value_fields, expr_columns) with expr_columns a list of (field, sql).
+        #
+        # Classification is by the rendered placeholder: a plain value -- and a
+        # database default, which resolves to a single bound value -- renders
+        # as "%s"; an expression such as Now() renders as its inline SQL.
         opts = self.query.get_meta()
         fields = self.query.fields or [opts.pk]
+        obj = self.query.objs[0]
+
+        value_row = [
+            self.prepare_value(field, self.pre_save_val(field, obj))
+            for field in fields
+        ]
+        placeholders = self.assemble_as_sql(fields, [value_row])[0][0]
+
+        value_fields = []
+        expr_columns = []
+        for field, placeholder in zip(fields, placeholders, strict=True):
+            if placeholder == "%s":
+                value_fields.append(field)
+            elif "%s" in placeholder:
+                # An expression with bound parameters can't be carried by the
+                # AS_TABLE($in_) row parameter nor inlined safely.
+                msg = (
+                    "Inserting a column from an expression with bound "
+                    "parameters is not supported on YDB."
+                )
+                raise NotSupportedError(msg)
+            else:
+                expr_columns.append((field, placeholder))
+        return value_fields, expr_columns
+
+    def _prepare_sql_statement(self, returning_columns, value_fields, expr_columns):
+        qn = self.connection.ops.quote_name
+        opts = self.query.get_meta()
 
         field_types = []
-        for f in fields:
+        for f in value_fields:
             yql_type = self.connection.introspection.get_yql_type(
                 _get_field_internal_type(f)
             )
             if getattr(f, "null", False):
                 yql_type = f"Optional<{yql_type}>"
             field_types.append(f"{qn(f.column)}: {yql_type}")
-        in_ = f"{', '.join(field_types)}"
 
-        select = (
-            f"SELECT {', '.join(qn(f.column) for f in fields)} FROM AS_TABLE($in_)"
-        )
+        # Plain columns are read from the input rows; expression columns (e.g.
+        # Now()) are evaluated inline for each row.
+        select_columns = [qn(f.column) for f in value_fields]
+        select_columns += [f"{sql} AS {qn(f.column)}" for f, sql in expr_columns]
+        insert_columns = [qn(f.column) for f in value_fields]
+        insert_columns += [qn(f.column) for f, _ in expr_columns]
+
+        select = f"SELECT {', '.join(select_columns)} FROM AS_TABLE($in_)"
         if returning_columns:
             # YDB returns database-generated keys (Serial) in input row order.
             select += f" RETURNING {', '.join(qn(c) for c in returning_columns)}"
 
         return [
-            f"DECLARE $in_ as List<Struct<{in_}>>;",
+            f"DECLARE $in_ as List<Struct<{', '.join(field_types)}>>;",
             f"{self._get_statement()} {qn(opts.db_table)}",
-            f"({', '.join(qn(f.column) for f in fields)})",
+            f"({', '.join(insert_columns)})",
             f"{select};",
         ]
 
-    def _prepare_params(self):
+    def _prepare_params(self, value_fields):
         opts = self.query.get_meta()
 
         if not self.query.fields:
@@ -617,20 +671,19 @@ class BaseSQLWriteCompiler(compiler.SQLInsertCompiler):
             )
             raise NotSupportedError(error_message)
 
-        fields = self.query.fields
         value_rows = [
             [
                 self.prepare_value(field, self.pre_save_val(field, obj))
-                for field in fields
+                for field in value_fields
             ]
             for obj in self.query.objs
         ]
 
-        _, param_rows = self.assemble_as_sql(fields, value_rows)
+        _, param_rows = self.assemble_as_sql(value_fields, value_rows)
         return {
             "$in_": (
-                _get_data(fields, param_rows),
-                _get_data_type(fields)
+                _get_data(value_fields, param_rows),
+                _get_data_type(value_fields)
             )
         }
 
@@ -638,8 +691,11 @@ class BaseSQLWriteCompiler(compiler.SQLInsertCompiler):
         raise NotImplementedError("Subclasses must implement this method")
 
     def as_sql(self, returning_columns=None):
-        sql = self._prepare_sql_statement(returning_columns)
-        params = self._prepare_params()
+        value_fields, expr_columns = self._split_fields()
+        sql = self._prepare_sql_statement(
+            returning_columns, value_fields, expr_columns
+        )
+        params = self._prepare_params(value_fields)
         return [(" ".join(sql), params)]
 
     def execute_sql(self, returning_fields=None):
@@ -671,9 +727,14 @@ class BaseSQLWriteCompiler(compiler.SQLInsertCompiler):
             if use_returning:
                 rows = [tuple(row) for row in returned]
             else:
-                # The PK is already known; echo it back from the inserted rows.
+                # The PK is already known; echo it back. For an auto field the
+                # value supplied may be a different type than the column stores
+                # (e.g. an integer PK created with a string), so coerce it to
+                # the field's Python type as a database read would.
+                coerce = opts.pk.to_python if auto_pk else (lambda value: value)
                 rows = [
-                    (self.pre_save_val(opts.pk, obj),) for obj in self.query.objs
+                    (coerce(self.pre_save_val(opts.pk, obj)),)
+                    for obj in self.query.objs
                 ]
 
             cols = [field.get_col(opts.db_table) for field in returning_fields]


### PR DESCRIPTION
Adds a CI job that runs Django's own bundled database test suite (`conformance/run.sh`) against YDB across the Python/Django matrix, so regressions in supported behavior are caught automatically. `basic` and `lookup` are **required on every Django version** (4.2, 5.2, 6.0) — no allow-failure — and the checked-out Django source is cached by version.

Making `basic`/`lookup` green on 5.2 and 6.0 meant fixing the version-specific failures the suite surfaced (rather than skipping or excluding versions):

- **Naive datetimes** shifted by the system timezone under `USE_TZ=False`. `_datetime_to_epoch_us` now treats a naive datetime as UTC so it round-trips, and the corresponding `django_test_skips` are removed. Closes #78.
- **Inserting an expression-valued column** (e.g. `Now()`) raised `IndexError`. The write compiler now emits expression columns inline in the `SELECT`, separate from the `AS_TABLE` row parameter, and `Now()` maps to `CurrentUtcTimestamp()` since YQL has no `CURRENT_TIMESTAMP` literal (refs #80).
- **An auto-field primary key** supplied as a different type (e.g. a string) is now coerced to the field's Python type on insert, as a database read would do.
- **`create_test_db()`** no longer forwards the `serialize` argument deprecated in Django 6.0 (`RemovedInDjango70Warning`), which the bundled test runner escalates to an error. Closes #90.

Verified locally: `conformance/run.sh basic lookup` is green on 4.2, 5.2 and 6.0; the project's own suite (292 tests, `USE_TZ=True`) is unaffected.

Closes #74
Closes #78
Closes #90
