### PR TITLE
Support Substr on Utf8 columns (Unicode::Substring)

### DIFF
--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -169,7 +169,7 @@ operation: it either raises `NotSupportedError` or skips with a warning.
 |---------|:------:|-------|
 | CRUD (`create`/`get`/`filter`/`update`/`delete`) | ✅ | |
 | Most field lookups | ✅ | `exact`, `in`, ranges, `icontains`, date-extract (`week_day`/`week`/`quarter`/...), etc. |
-| Backslash / `%` / `_` escaping in pattern & exact lookups | ✅ | Escaped correctly via `ESCAPE '~'` (issue #75). `Substr()` on a text column is still unsupported (#87). |
+| Backslash / `%` / `_` escaping in pattern & exact lookups | ✅ | Escaped correctly via `ESCAPE '~'` (issue #75). `Substr()` on a text column works via `Unicode::Substring` (#87); a pattern lookup whose right-hand side is a *nullable* expression remains unsupported (#91). |
 | Coercing lookups (`int`-as-`str`, `date`-as-`str`), regex on NULL/non-string | ❌ | Raise during parameter handling. |
 | Correlated subqueries (`Exists`/`Subquery`/`OuterRef` as LHS) | ❌ | YDB cannot resolve the outer reference (issue #77). Non-correlated subqueries work. |
 | Aggregation / annotation | 🟡 | GROUP BY validation fixed (#76); tail remains: `ORDER BY` aggregated values, `GROUP BY` constant, `PI()`/`Random()`/`CURRENT_TIMESTAMP` (issue #80). |

--- a/tests/compiler/test_pattern_escaping.py
+++ b/tests/compiler/test_pattern_escaping.py
@@ -1,4 +1,5 @@
 from django.db.models import F
+from django.db.models.functions import Substr
 from django.test import TransactionTestCase
 
 from .models import Book
@@ -80,4 +81,38 @@ class PatternLookupExpressionTest(TransactionTestCase):
         Book.objects.create(isbn="24", title="10X off", author="10%", price=1)
         self.assertCountEqual(
             Book.objects.filter(title__startswith=F("author")), [literal]
+        )
+
+
+class SubstrTest(TransactionTestCase):
+    """Substr() on a Utf8 column, 1-indexed (issue #87)."""
+
+    def test_substr_is_one_indexed(self):
+        obj = Book.objects.annotate(
+            head=Substr("author", 1, 3),
+            tail=Substr("author", 4),
+        ).get(
+            isbn=Book.objects.create(
+                isbn="40", title="t", author="abcdef", price=1
+            ).isbn
+        )
+        self.assertEqual(obj.head, "abc")
+        self.assertEqual(obj.tail, "def")
+
+    def test_pattern_lookup_with_substr(self):
+        a = Book.objects.create(
+            isbn="41", title="John Smith", author="Johx", price=1
+        )
+        b = Book.objects.create(
+            isbn="42", title="Rhonda Simpson", author="sonx", price=1
+        )
+        # Substr(author, 1, 3) is "Joh" / "son".
+        self.assertCountEqual(
+            Book.objects.filter(title__startswith=Substr("author", 1, 3)), [a]
+        )
+        self.assertCountEqual(
+            Book.objects.filter(title__contains=Substr("author", 1, 3)), [a, b]
+        )
+        self.assertCountEqual(
+            Book.objects.filter(title__endswith=Substr("author", 1, 3)), [b]
         )

--- a/ydb_backend/backend/features.py
+++ b/ydb_backend/backend/features.py
@@ -232,9 +232,9 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             "lookup.tests.LookupTests.test_exact_exists",
             "lookup.tests.LookupTests.test_nested_outerref_lhs",
         },
-        "Substr/SUBSTRING is unsupported on Utf8 columns (YQL SUBSTRING expects "
-        "String); see issue #87. Pattern/exact lookup string escaping is "
-        "otherwise fixed (#75).": {
+        "A pattern lookup over a nullable expression RHS builds an "
+        "Optional<Utf8> LIKE pattern that YQL rejects (see issue #91); the "
+        "RHS here is Substr() over the nullable Author.alias.": {
             "lookup.tests.LookupTests.test_pattern_lookups_with_substr",
         },
         "Lookups that coerce a value to a different field type (int-as-str, "

--- a/ydb_backend/backend/operations.py
+++ b/ydb_backend/backend/operations.py
@@ -3,6 +3,7 @@ import json
 
 from django.db.backends.base.operations import BaseDatabaseOperations
 from django.db.models.functions import Now
+from django.db.models.functions import Substr
 
 
 def _now_as_ydb(self, compiler, connection, **extra_context):
@@ -15,6 +16,27 @@ def _now_as_ydb(self, compiler, connection, **extra_context):
 
 
 Now.as_ydb = _now_as_ydb
+
+
+def _substr_as_ydb(self, compiler, connection, **extra_context):  # noqa: ARG001
+    # YQL's SUBSTRING built-in rejects Utf8 (CharField/TextField map to Utf8)
+    # and is 0-indexed, whereas Django's Substr is 1-indexed. Use the
+    # Utf8-native Unicode::Substring and shift the position by one.
+    source, pos, *length = self.source_expressions
+    source_sql, params = compiler.compile(source)
+    pos_sql, pos_params = compiler.compile(pos)
+    # Unicode::Substring takes Uint64 offsets; Django's pos is 1-based and
+    # bound as a signed integer, so shift to 0-based and cast.
+    parts = [source_sql, f"CAST(({pos_sql}) - 1 AS Uint64)"]
+    params = [*params, *pos_params]
+    if length:
+        length_sql, length_params = compiler.compile(length[0])
+        parts.append(f"CAST({length_sql} AS Uint64)")
+        params.extend(length_params)
+    return f"Unicode::Substring({', '.join(parts)})", params
+
+
+Substr.as_ydb = _substr_as_ydb
 
 DATE_PARAMS_EXTRACT = [
     "year",


### PR DESCRIPTION
Django's `Substr` compiled to YQL `SUBSTRING()`, which rejects `Utf8` (where `CharField`/`TextField` live) and is 0-indexed, whereas `Substr` is 1-indexed — so it errored on text columns and would have been off by one. Map `Substr` to the Utf8-native `Unicode::Substring`, shifting the 1-based position to 0-based and casting the `Uint64` offsets.

Verified by `tests/compiler/test_pattern_escaping.py::SubstrTest` (1-indexing and a `Substr`-based pattern lookup).

The conformance test that exercises this on a nullable column (`lookup.tests.LookupTests.test_pattern_lookups_with_substr`, `Author.alias` is `null=True`) additionally needs nullable-expression-RHS support in LIKE — a separate gap tracked in #91 — so it stays skipped with that reason.

Closes #87
