### PR TITLE
fix: relation-conformance gaps in DELETE and dates()

### DIFF
--- a/tests/backends/ydb/test_operations.py
+++ b/tests/backends/ydb/test_operations.py
@@ -59,11 +59,18 @@ class TestDatabaseOperations(SimpleTestCase):
             "hour", "column_name", [], tzname=TZ_NAME
         )
 
-        self.assertEqual(sql_dt, "DateTime::StartOfYear(column_name)")
+        # StartOf* yields a Resource the driver cannot read, so the column is
+        # narrowed (Date/Timestamp) and the result materialised with a Make*
+        # function (see issue #93).
+        self.assertEqual(
+            sql_dt,
+            "DateTime::MakeDate(DateTime::StartOfYear(CAST(column_name AS Date)))",
+        )
         self.assertEqual(
             sql_dttm,
-            "DateTime::StartOf((AddTimezone(column_name, 'Europe/Moscow')), "
-            "Interval('PT1H'))",
+            "DateTime::MakeTimestamp(DateTime::StartOf("
+            "(AddTimezone(CAST(column_name AS Timestamp), 'Europe/Moscow')), "
+            "Interval('PT1H')))",
         )
         self.assertListEqual(params_dt, [])
 

--- a/tests/compiler/test_delete.py
+++ b/tests/compiler/test_delete.py
@@ -1,6 +1,8 @@
 from django.db.models import Q
 from django.test import TransactionTestCase
 
+from .models import Product
+from .models import ProductReview
 from .models import SimpleItem
 
 
@@ -88,6 +90,27 @@ class TestDelete(TransactionTestCase):
         ).delete()
 
         self.assertEqual(SimpleItem.objects.count(), 1)
+
+    def test_delete_filtered_by_related_field(self):
+        # Regression for issue #94: a DELETE whose WHERE filters on a joined
+        # (related) field is rewritten to ``pk IN (subquery)``. The subquery's
+        # bound parameter must be declared at the DELETE statement scope; before
+        # the fix it surfaced as "Unknown name: $element_1".
+        keep = Product.objects.create(
+            sku="P-KEEP", name="Keep", category="x", price=10, stock=5
+        )
+        drop = Product.objects.create(
+            sku="P-DROP", name="Drop", category="y", price=20, stock=3
+        )
+        ProductReview.objects.create(product=keep, rating=5)
+        ProductReview.objects.create(product=drop, rating=4)
+
+        ProductReview.objects.filter(product__name="Drop").delete()
+
+        self.assertEqual(ProductReview.objects.count(), 1)
+        self.assertEqual(
+            ProductReview.objects.filter(product__name="Drop").count(), 0
+        )
 
     def test_delete_all(self):
         SimpleItem.objects.create(

--- a/tests/type/test_date_time_fields.py
+++ b/tests/type/test_date_time_fields.py
@@ -4,6 +4,10 @@ from datetime import timedelta
 from datetime import timezone as stdlib_timezone
 
 from django.db.models.functions import TruncDate
+from django.db.models.functions import TruncDay
+from django.db.models.functions import TruncHour
+from django.db.models.functions import TruncMonth
+from django.db.models.functions import TruncYear
 from django.test import SimpleTestCase
 from django.utils import timezone
 
@@ -196,6 +200,71 @@ class TimeFieldsTest(SimpleTestCase):
             date_only=TruncDate("datetime_field")
         ).get(date_field=date(2010, 2, 17))
         self.assertEqual(obj.date_only, date(2016, 12, 5))
+
+    def test_date_field_truncate(self):
+        # Exercises date_trunc_sql (DateField -> MakeDate). StartOf* returns a
+        # Resource the driver cannot read, so the result must be materialised
+        # back to a Date (issue #93).
+        TimeModel.objects.all().delete()
+        TimeModel.objects.create(
+            date_field=date(1980, 4, 23),
+            datetime_field=datetime(1980, 4, 23, 9, 30, tzinfo=stdlib_timezone.utc),
+            duration_field=timedelta(days=1),
+        )
+        obj = TimeModel.objects.annotate(
+            d_year=TruncYear("date_field"),
+            d_month=TruncMonth("date_field"),
+            d_day=TruncDay("date_field"),
+        ).get()
+        self.assertEqual(obj.d_year, date(1980, 1, 1))
+        self.assertEqual(obj.d_month, date(1980, 4, 1))
+        self.assertEqual(obj.d_day, date(1980, 4, 23))
+
+    def test_dates_distinct(self):
+        # QuerySet.dates() builds SELECT DISTINCT <truncated date> ORDER BY the
+        # alias. Regression for issue #93: before the fix the ORDER BY term
+        # re-referenced the base column the DISTINCT projection had dropped.
+        TimeModel.objects.all().delete()
+        for d in (date(1980, 4, 23), date(1980, 4, 23), date(2005, 7, 27)):
+            TimeModel.objects.create(
+                date_field=d,
+                datetime_field=datetime(
+                    d.year, d.month, d.day, tzinfo=stdlib_timezone.utc
+                ),
+                duration_field=timedelta(days=1),
+            )
+        self.assertEqual(
+            list(TimeModel.objects.dates("date_field", "day")),
+            [date(1980, 4, 23), date(2005, 7, 27)],
+        )
+        self.assertEqual(
+            list(TimeModel.objects.dates("date_field", "month")),
+            [date(1980, 4, 1), date(2005, 7, 1)],
+        )
+
+    def test_datetime_field_truncate_units(self):
+        # Exercises datetime_trunc_sql (DateTimeField -> MakeTimestamp).
+        # Truncation happens in the active timezone; pin it to UTC for a
+        # deterministic result.
+        TimeModel.objects.all().delete()
+        TimeModel.objects.create(
+            date_field=date(2016, 12, 5),
+            datetime_field=datetime(
+                2016, 12, 5, 14, 30, 15, tzinfo=stdlib_timezone.utc
+            ),
+            duration_field=timedelta(days=1),
+        )
+        with timezone.override(stdlib_timezone.utc):
+            obj = TimeModel.objects.annotate(
+                t_month=TruncMonth("datetime_field"),
+                t_hour=TruncHour("datetime_field"),
+            ).get()
+        self.assertEqual(
+            obj.t_month, datetime(2016, 12, 1, tzinfo=stdlib_timezone.utc)
+        )
+        self.assertEqual(
+            obj.t_hour, datetime(2016, 12, 5, 14, 0, tzinfo=stdlib_timezone.utc)
+        )
 
     def test_field_components(self):
         TimeModel.objects.create(

--- a/ydb_backend/backend/features.py
+++ b/ydb_backend/backend/features.py
@@ -324,14 +324,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             "queries.test_contains.ContainsTests.test_wrong_model",
         },
         # --- relation modules (issue #74 conformance expansion). ---
-        "select_related().dates() does not project the date column it groups "
-        "on (see issue #93).": {
-            "many_to_one.tests.ManyToOneTests.test_select_related",
-        },
-        "DELETE filtered by a related field generates an undeclared parameter "
-        "(see issue #94).": {
-            "one_to_one.tests.OneToOneTests.test_o2o_primary_key_delete",
-        },
         "YDB does not enforce uniqueness, so creating a duplicate OneToOne does "
         "not raise IntegrityError (uniqueness is an application responsibility).": {
             "one_to_one.tests.OneToOneTests.test_multiple_o2o",

--- a/ydb_backend/backend/operations.py
+++ b/ydb_backend/backend/operations.py
@@ -206,9 +206,9 @@ class DatabaseOperations(BaseDatabaseOperations):
 
     def date_trunc_sql(self, lookup_type, sql, params, tzname=None):
         """
-        Given a lookup_type of 'year', 'month', or 'day', return the SQL that
-        truncates the given date or datetime field field_name to a date object
-        with only the given specificity.
+        Given a lookup_type of 'year', 'quarter', 'month', 'week', or 'day',
+        return the SQL that truncates the given date or datetime field
+        field_name to a date object with only the given specificity.
 
         If `tzname` is provided, the given value is truncated in a specific
         timezone.
@@ -266,9 +266,10 @@ class DatabaseOperations(BaseDatabaseOperations):
 
     def datetime_trunc_sql(self, lookup_type, sql, params, tzname):
         """
-        Given a lookup_type of 'year', 'month', 'day', 'hour', 'minute', or
-        'second', return the SQL that truncates the given datetime field
-        field_name to a datetime object with only the given specificity.
+        Given a lookup_type of 'year', 'quarter', 'month', 'week', 'day',
+        'hour', 'minute', or 'second', return the SQL that truncates the given
+        datetime field field_name to a datetime object with only the given
+        specificity.
         """
         # As in date_trunc_sql, narrow the wide Timestamp64 the backend stores
         # datetimes in to Timestamp before AddTimezone/StartOf, then materialise

--- a/ydb_backend/backend/operations.py
+++ b/ydb_backend/backend/operations.py
@@ -111,20 +111,26 @@ def _common_dt_dttm_extract_funcs(lookup_type, sql, params):
     raise ValueError(msg)
 
 
+# StartOf* family by Django truncation lookup type. Each operates on a narrow
+# Date/Datetime/Timestamp and yields a Resource<DateTime2.TM> "split" value, so
+# every caller must materialise the result back with a Make* function.
+_START_OF_FUNCS = {
+    "year": "StartOfYear",
+    "quarter": "StartOfQuarter",
+    "month": "StartOfMonth",
+    "week": "StartOfWeek",
+    "day": "StartOfDay",
+}
+
+
 # common code for methods date_trunc_sql and datetime_trunc_sql
-def _common_dt_dttm_trunc_funcs(lookup_type, sql, params):
-    if lookup_type == "year":
-        return f"DateTime::StartOfYear({sql})", params
-    if lookup_type == "quarter":
-        return f"DateTime::StartOfQuarter({sql})", params
-    if lookup_type == "month":
-        return f"Datetime::StartOfMonth({sql})", params
-    if lookup_type == "week":
-        return f"Datetime::StartOfWeek({sql})", params
-    if lookup_type == "day":
-        return f"Datetime::StartOfDay({sql})", params
-    msg = f"Unsupported lookup type: {lookup_type}"
-    raise ValueError(msg)
+def _start_of_sql(lookup_type, sql):
+    try:
+        func = _START_OF_FUNCS[lookup_type]
+    except KeyError:
+        msg = f"Unsupported lookup type: {lookup_type}"
+        raise ValueError(msg) from None
+    return f"DateTime::{func}({sql})"
 
 
 def _add_tzname(sql, tzname):
@@ -200,15 +206,20 @@ class DatabaseOperations(BaseDatabaseOperations):
 
     def date_trunc_sql(self, lookup_type, sql, params, tzname=None):
         """
-        iven a lookup_type of 'year', 'month', or 'day', return the SQL that
+        Given a lookup_type of 'year', 'month', or 'day', return the SQL that
         truncates the given date or datetime field field_name to a date object
         with only the given specificity.
 
         If `tzname` is provided, the given value is truncated in a specific
         timezone.
         """
-        sql = _add_tzname(sql, tzname)
-        return _common_dt_dttm_trunc_funcs(lookup_type, sql, params)
+        # StartOf* reject the wide Date32 the backend stores dates in and return
+        # a Resource the driver cannot read, so narrow the column to Date,
+        # truncate, then materialise the result back to a Date with MakeDate.
+        # Narrow Date spans 1970-2105; truncating dates outside that range is
+        # unsupported.
+        sql = _add_tzname(f"CAST({sql} AS Date)", tzname)
+        return f"DateTime::MakeDate({_start_of_sql(lookup_type, sql)})", params
 
     def datetime_cast_date_sql(self, sql, params, tzname):
         """
@@ -259,21 +270,27 @@ class DatabaseOperations(BaseDatabaseOperations):
         'second', return the SQL that truncates the given datetime field
         field_name to a datetime object with only the given specificity.
         """
-        sql = _add_tzname(sql, tzname)
+        # As in date_trunc_sql, narrow the wide Timestamp64 the backend stores
+        # datetimes in to Timestamp before AddTimezone/StartOf, then materialise
+        # the Resource result back with MakeTimestamp. Narrow Timestamp spans
+        # 1970-2105.
+        sql = _add_tzname(f"CAST({sql} AS Timestamp)", tzname)
 
         if lookup_type in DATE_PARAMS_TRUNC:
-            return _common_dt_dttm_trunc_funcs(lookup_type, sql, params)
-        if lookup_type == "hour":
-            return f"DateTime::StartOf(({sql}), Interval('PT1H'))", params
-        if lookup_type == "minute":
-            return f"DateTime::StartOf(({sql}), Interval('PT1M'))", params
-        if lookup_type == "second":
-            return f"DateTime::StartOf(({sql}), Interval('PT1S'))", params
-        if lookup_type == "millisecond":
-            return f"DateTime::StartOf(({sql}), Interval('PT01S'))", params
+            inner = _start_of_sql(lookup_type, sql)
+        else:
+            interval = {
+                "hour": "PT1H",
+                "minute": "PT1M",
+                "second": "PT1S",
+                "millisecond": "PT01S",
+            }.get(lookup_type)
+            if interval is None:
+                msg = f"Unsupported lookup type: {lookup_type}"
+                raise ValueError(msg)
+            inner = f"DateTime::StartOf(({sql}), Interval('{interval}'))"
 
-        msg = f"Unsupported lookup type: {lookup_type}"
-        raise ValueError(msg)
+        return f"DateTime::MakeTimestamp({inner})", params
 
     def time_trunc_sql(self, lookup_type, sql, params, tzname=None):
         """

--- a/ydb_backend/models/sql/compiler.py
+++ b/ydb_backend/models/sql/compiler.py
@@ -312,6 +312,15 @@ def _get_data_type(fields):
 class SQLCompiler(_ParamTypingMixin, SQLCompiler):
     def get_order_by(self):
         result = super().get_order_by()
+        # Under SELECT DISTINCT, YQL resolves ORDER BY against the projected
+        # output columns only. Map each selected column's SQL to its alias so an
+        # order-by term that re-emits a select expression can reference that
+        # alias instead of a base column the projection has dropped (issue #93).
+        distinct_aliases = {}
+        if self.query.distinct and not self.query.distinct_fields:
+            for _, (s_sql, _), s_alias in self.select:
+                if s_alias:
+                    distinct_aliases.setdefault(s_sql, s_alias)
         # YDB rejects "ORDER BY N" (ordinal position reference, a Django 5.x
         # optimisation via PositionRef). Re-compile affected entries with the
         # underlying source expression so the actual column name is emitted.
@@ -329,7 +338,25 @@ class SQLCompiler(_ParamTypingMixin, SQLCompiler):
                 entry_sql, entry_params = self.compile(new_resolved)
             else:
                 entry_sql, entry_params = o_sql, o_params
-            fixed.append((resolved, (entry_sql, entry_params, is_ref)))
+            entry_is_ref = is_ref
+            if distinct_aliases:
+                # Strip the trailing direction (ASC/DESC) to match the bare
+                # select SQL. The keys are full select expressions, so a plain
+                # alias reference (already safe under DISTINCT) never matches;
+                # only a re-emitted expression -- whether a non-ref term or a
+                # PositionRef expanded just above -- is rewritten to its alias.
+                # Drop the now-duplicated params (bound by the select column)
+                # and mark the entry as a reference so get_extra_select() does
+                # not re-add the alias as an extra projected column.
+                match = self.ordering_parts.search(entry_sql)
+                base = match[1] if match else entry_sql
+                alias = distinct_aliases.get(base)
+                if alias:
+                    direction = entry_sql[len(base):]
+                    entry_sql = f"{self.connection.ops.quote_name(alias)}{direction}"
+                    entry_params = []
+                    entry_is_ref = True
+            fixed.append((resolved, (entry_sql, entry_params, entry_is_ref)))
         return fixed
 
     def as_sql(self, with_limits=True, with_col_aliases=False):
@@ -825,8 +852,15 @@ class SQLDeleteCompiler(_ParamTypingMixin, compiler.SQLDeleteCompiler):
         outerq = Query(self.query.model)
         if not self.connection.features.update_can_self_select:
             # Force the materialization of the inner query to allow reference
-            # to the target table on MySQL.
-            sql, params = innerq.get_compiler(connection=self.connection).as_sql()
+            # to the target table. Compile it in subquery mode so it yields
+            # ``%s`` placeholders with a positional ``_TypedParam`` list rather
+            # than SQL with baked-in ``$element_N`` names and a params dict:
+            # the enclosing DELETE names every placeholder once. Otherwise the
+            # inner ``$element_N`` is emitted into the final SQL but never
+            # declared ("Unknown name: $element_1", issue #94).
+            inner_compiler = innerq.get_compiler(connection=self.connection)
+            inner_compiler.query.subquery = True
+            sql, params = inner_compiler.as_sql()
             innerq = RawSQL(f"SELECT * FROM ({sql}) subquery", params) # noqa: S611
         outerq.add_filter("pk__in", innerq)
         return self._as_sql(outerq)


### PR DESCRIPTION
Closes #94
Closes #93

## #94 — DELETE filtered by a related field

A DELETE whose WHERE filters on a joined field is rewritten to `pk IN (subquery)`. The materialised inner query was compiled in normal mode, baking in `$element_N` names and a params dict that the enclosing DELETE's placeholder pass ignored, so the parameter was referenced but never declared (`Unknown name: $element_1`). It is now compiled in subquery mode (`%s` plus a positional `_TypedParam` list) so the outer statement names every placeholder once — the same composition path already used for combinators and aggregates.

## #93 — `select_related().dates()`

Two defects surfaced:

- **ORDER BY under `SELECT DISTINCT`** — YQL resolves ORDER BY against the projected columns only. An order-by term that re-emitted a select expression referenced a base column the projection had dropped (`Column pub_date is not in source column set`). It is now rewritten to reference that column's select alias.
- **Date truncation** — `DateTime::StartOf*` returns a `Resource<DateTime2.TM>` the driver cannot read, so `dates()`/`datetimes()` crashed outright. The wide `Date32`/`Timestamp64` column is now narrowed, truncated, and materialised back with `MakeDate`/`MakeTimestamp`.

Both previously-skipped conformance tests (`one_to_one…test_o2o_primary_key_delete`, `many_to_one…test_select_related`) now pass and are removed from `django_test_skips`. Adds regression tests for the related-field delete and for date truncation/`dates()`, and updates the trunc unit test.

Part of the #51 non-beta release backlog (relation-conformance gaps from #74).