### PR TITLE
fix: support nullable expression RHS in pattern lookups

### DIFF
--- a/tests/compiler/models.py
+++ b/tests/compiler/models.py
@@ -8,6 +8,9 @@ class Book(models.Model):
     author = models.TextField(max_length=255)
     isbn = models.CharField(max_length=13, primary_key=True)
     price = models.IntegerField()
+    # Nullable so a pattern lookup with an expression RHS over it produces an
+    # Optional<Utf8> pattern (issue #91); mirrors Django's own Author.alias.
+    alias = models.TextField(null=True)  # noqa: DJ001
 
     def __str__(self):
         return (

--- a/tests/compiler/test_pattern_escaping.py
+++ b/tests/compiler/test_pattern_escaping.py
@@ -116,3 +116,46 @@ class SubstrTest(TransactionTestCase):
         self.assertCountEqual(
             Book.objects.filter(title__endswith=Substr("author", 1, 3)), [b]
         )
+
+
+class PatternLookupNullableExpressionTest(TransactionTestCase):
+    """An expression RHS over a nullable column (issue #91).
+
+    The LIKE pattern is then ``Optional<Utf8>``, which YQL rejects; pattern_esc
+    COALESCEs it to a non-optional Utf8 and a guard ensures a NULL right-hand
+    side excludes the row rather than matching every row (empty pattern).
+    """
+
+    def test_substr_over_nullable_column(self):
+        a = Book.objects.create(
+            isbn="50", title="John Smith", author="x", alias="Johx", price=1
+        )
+        b = Book.objects.create(
+            isbn="51", title="Rhonda Simpson", author="x", alias="sonx", price=1
+        )
+        # alias is NULL: Substr(alias, 1, 3) is NULL and must match nothing, not
+        # collapse to an empty pattern that matches every row.
+        Book.objects.create(
+            isbn="52", title="anything", author="x", alias=None, price=1
+        )
+        self.assertCountEqual(
+            Book.objects.filter(title__startswith=Substr("alias", 1, 3)), [a]
+        )
+        self.assertCountEqual(
+            Book.objects.filter(title__icontains=Substr("alias", 1, 3)), [a, b]
+        )
+        self.assertCountEqual(
+            Book.objects.filter(title__endswith=Substr("alias", 1, 3)), [b]
+        )
+
+    def test_null_column_rhs_excludes_row(self):
+        match = Book.objects.create(
+            isbn="53", title="hello world", author="x", alias="hello", price=1
+        )
+        # A NULL alias must not match, even though its column is the RHS.
+        Book.objects.create(
+            isbn="54", title="hello world", author="x", alias=None, price=1
+        )
+        self.assertCountEqual(
+            Book.objects.filter(title__startswith=F("alias")), [match]
+        )

--- a/ydb_backend/backend/base.py
+++ b/ydb_backend/backend/base.py
@@ -115,9 +115,14 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     # ``%`` is used (not the SQL-standard doubled ``%%``): this backend resolves
     # parameters by name and never ``%``-formats the assembled query, so ``%%``
     # would reach YDB doubled and break the literal-percent escaping.
+    # The expression is COALESCEd to a non-optional Utf8: an expression over a
+    # nullable column is Optional<Utf8>, and YQL's LIKE rejects an Optional
+    # pattern (issue #91). A NULL right-hand side then yields an empty pattern
+    # (match-all), which the pattern-lookup as_sql override in operations.py
+    # corrects with a trailing "IS NOT NULL" guard so a NULL excludes the row.
     pattern_esc = (
         "Unicode::ReplaceAll(Unicode::ReplaceAll(Unicode::ReplaceAll("
-        "{}, '~'u, '~~'u), '%'u, '~%'u), '_'u, '~_'u)"
+        "COALESCE({}, ''u), '~'u, '~~'u), '%'u, '~%'u), '_'u, '~_'u)"
     )
     pattern_ops = {
         "contains": "LIKE '%'u || {} || '%'u ESCAPE '~'",

--- a/ydb_backend/backend/features.py
+++ b/ydb_backend/backend/features.py
@@ -232,11 +232,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             "lookup.tests.LookupTests.test_exact_exists",
             "lookup.tests.LookupTests.test_nested_outerref_lhs",
         },
-        "A pattern lookup over a nullable expression RHS builds an "
-        "Optional<Utf8> LIKE pattern that YQL rejects (see issue #91); the "
-        "RHS here is Substr() over the nullable Author.alias.": {
-            "lookup.tests.LookupTests.test_pattern_lookups_with_substr",
-        },
         "Lookups that coerce a value to a different field type (int-as-str, "
         "date-as-str) or apply regex to non-string/NULL operands raise during "
         "parameter handling.": {

--- a/ydb_backend/backend/operations.py
+++ b/ydb_backend/backend/operations.py
@@ -5,6 +5,7 @@ from django.db.backends.base.operations import BaseDatabaseOperations
 from django.db.models.functions import Now
 from django.db.models.functions import Pi
 from django.db.models.functions import Substr
+from django.db.models.lookups import PatternLookup
 
 
 def _now_as_ydb(self, compiler, connection, **extra_context):
@@ -48,6 +49,44 @@ def _pi_as_ydb(self, compiler, connection, **extra_context):
 
 
 Pi.as_ydb = _pi_as_ydb
+
+
+_pattern_lookup_as_sql = PatternLookup.as_sql
+
+
+def _pattern_lookup_as_sql_ydb(self, compiler, connection):
+    # A pattern lookup (contains/startswith/endswith and the i* variants) whose
+    # right-hand side is an expression -- a column reference or a transform such
+    # as Substr -- over a nullable column builds an Optional<Utf8> LIKE pattern
+    # that YQL's LIKE rejects ("String != Optional<Utf8>", issue #91). pattern_esc
+    # COALESCEs the expression to a non-optional Utf8 so the pattern type-checks,
+    # but that turns a NULL right-hand side into an empty (match-everything)
+    # pattern, so a trailing "rhs IS NOT NULL" guard excludes those rows instead.
+    #
+    # The right-hand side is emitted twice (the pattern and the guard); compiling
+    # it through the compiler each time keeps its parameters and the per-parameter
+    # type capture aligned. Anything but this case defers to Django's
+    # implementation.
+    if (
+        connection.vendor != "ydb"
+        or self.lookup_name not in connection.pattern_ops
+        or not (hasattr(self.rhs, "as_sql") or self.bilateral_transforms)
+    ):
+        return _pattern_lookup_as_sql(self, compiler, connection)
+    lhs_sql, params = self.process_lhs(compiler, connection)
+    rhs_sql, rhs_params = self.process_rhs(compiler, connection)
+    rhs_op = connection.pattern_ops[self.lookup_name].format(
+        connection.pattern_esc
+    ).format(rhs_sql)
+    # process_rhs again for the guard so a bilateral transform (where self.rhs is
+    # a value, not an expression) is handled the same way; it does not mutate
+    # params on this path.
+    guard_sql, guard_params = self.process_rhs(compiler, connection)
+    sql = f"({lhs_sql} {rhs_op} AND ({guard_sql}) IS NOT NULL)"
+    return sql, [*params, *rhs_params, *guard_params]
+
+
+PatternLookup.as_sql = _pattern_lookup_as_sql_ydb
 
 DATE_PARAMS_EXTRACT = [
     "year",


### PR DESCRIPTION
Closes #91

## Problem

A pattern lookup (`contains`/`startswith`/`endswith` and the `i*` variants) whose right-hand side is an **expression over a nullable column** — a column reference or a transform such as `Substr` — builds the LIKE pattern by concatenation, yielding an `Optional<Utf8>`. YQL's LIKE rejects it:

```
Callable is produced by Udf: Re2.PatternFromLike
Mismatch type argument #1, type diff: String != Optional<Utf8>
```

It is a pure type problem: it fails even when no row is actually NULL.

## Fix

- **`pattern_esc`** now `COALESCE`s the expression to a non-optional `Utf8` so the pattern type-checks.
- That alone turns a NULL right-hand side into an empty (match-everything) pattern, so **`PatternLookup.as_sql` is overridden on YDB** to append a `rhs IS NOT NULL` guard — a NULL right-hand side excludes the row instead of matching all. This is the behaviour `pattern_ops` alone cannot express.
- The right-hand side is emitted twice (pattern and guard); compiling it through the compiler each time keeps its parameters and the per-parameter type capture aligned, so both `Substr(...)` (own params) and a bare `F(...)` (no params) work. Non-YDB, direct-value, and non-pattern lookups defer to Django's implementation.

Removes the `django_test_skips` entry for `lookup.tests.LookupTests.test_pattern_lookups_with_substr` and adds regression tests over a nullable column, including the NULL-excludes-the-row case (a bare `COALESCE` to `''` would otherwise match every row).

Part of the #51 non-beta release backlog (conformance gaps from #72).