### PR TITLE
feat: support __hour/__minute/__second lookups on TimeField

### DIFF
--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -80,7 +80,7 @@ Full type mapping is in [FIELDS.md](FIELDS.md). Status of each Django field:
 | `DateField` | ✅ | `Date32` (signed wide); pre-1970 dates round-trip. |
 | `DateTimeField` (`USE_TZ=True`) | ✅ | `Timestamp64` (signed wide), microsecond precision, pre-1970 instants. |
 | `DateTimeField` (`USE_TZ=False`) | 🟡 | Naive datetimes shift by the server timezone on round-trip (issue #78). Microsecond precision is fine. Production default `USE_TZ=True` is unaffected. |
-| `TimeField` | 🟡 | No native YDB time type; stored as `Int64` microseconds-since-midnight, introspected back as `BigIntegerField`. `__hour`/`__minute`/`__second` lookups are unsupported (#81). |
+| `TimeField` | 🟡 | No native YDB time type; stored as `Int64` microseconds-since-midnight, introspected back as `BigIntegerField`. `__hour`/`__minute`/`__second` lookups are supported (computed by integer arithmetic on the stored value). |
 | `JSONField` | 🟡 | Native `Json`. Equality filter (`filter(data=value)`) is unsupported by YDB; cannot be introspected; no `JSONObject()`. `null=True` is documented as unsupported (see [FIELDS.md](FIELDS.md)); to be re-verified (#83). |
 
 ## Relations

--- a/tests/type/models.py
+++ b/tests/type/models.py
@@ -81,6 +81,14 @@ class TimeModel(models.Model):
         )
 
 
+class AlarmModel(models.Model):
+    desc = models.CharField(max_length=100)
+    time = models.TimeField()
+
+    def __str__(self):
+        return f"{self.desc} {self.time}"
+
+
 class TextRelatedModel(models.Model):
     char_field = models.CharField(max_length=255)
     text_field = models.TextField()

--- a/tests/type/test_date_time_fields.py
+++ b/tests/type/test_date_time_fields.py
@@ -1,5 +1,6 @@
 from datetime import date
 from datetime import datetime
+from datetime import time
 from datetime import timedelta
 from datetime import timezone as stdlib_timezone
 
@@ -9,8 +10,10 @@ from django.db.models.functions import TruncHour
 from django.db.models.functions import TruncMonth
 from django.db.models.functions import TruncYear
 from django.test import SimpleTestCase
+from django.test import TransactionTestCase
 from django.utils import timezone
 
+from .models import AlarmModel
 from .models import TimeModel
 
 
@@ -323,3 +326,35 @@ class TimeFieldsTest(SimpleTestCase):
     #     qs = TimeModel.objects.filter(date_field__year=2023, date_field__month=5)
     #     self.assertEqual(qs.count(), 1)
     #     self.assertEqual(qs.first().date_field, date(2023, 5, 15))
+
+
+class TimeFieldLookupTest(TransactionTestCase):
+    """__hour/__minute/__second on a TimeField (issue #81).
+
+    TimeField is stored as Int64 microseconds since midnight, so the components
+    are extracted with integer arithmetic rather than DateTime::Get*.
+    """
+
+    databases = {"default"}
+
+    def setUp(self):
+        self.early = AlarmModel.objects.create(desc="Early", time=time(5, 30))
+        self.late = AlarmModel.objects.create(desc="Late", time=time(10, 0))
+        self.precise = AlarmModel.objects.create(
+            desc="Precise", time=time(12, 34, 56)
+        )
+
+    def test_hour_lookup(self):
+        self.assertCountEqual(
+            AlarmModel.objects.filter(time__hour=5), [self.early]
+        )
+
+    def test_minute_lookup(self):
+        self.assertCountEqual(
+            AlarmModel.objects.filter(time__minute=30), [self.early]
+        )
+
+    def test_second_lookup(self):
+        self.assertCountEqual(
+            AlarmModel.objects.filter(time__second=56), [self.precise]
+        )

--- a/ydb_backend/backend/features.py
+++ b/ydb_backend/backend/features.py
@@ -219,11 +219,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             "basic.tests.SelectOnSaveTests.test_select_on_save_lying_update",
         },
         # --- lookup module (issue #72), grouped by observed failure mode. ---
-        "TimeField is not supported: YDB has no native time type.": {
-            "lookup.test_timefield.TimeFieldLookupTests.test_hour_lookups",
-            "lookup.test_timefield.TimeFieldLookupTests.test_minute_lookups",
-            "lookup.test_timefield.TimeFieldLookupTests.test_second_lookups",
-        },
         "A subquery used as the left-hand side of a lookup (Exists/OuterRef/"
         "subquery LHS) resolves to an unknown YQL member; correlated subqueries "
         "are unsupported.": {

--- a/ydb_backend/backend/operations.py
+++ b/ydb_backend/backend/operations.py
@@ -407,12 +407,29 @@ class DatabaseOperations(BaseDatabaseOperations):
             return []
         return [self.sql_flush_table(style, table) for table in tables]
 
+    # Divisor (microseconds per unit) and modulus for extracting a component
+    # from a TimeField, stored as Int64 microseconds since midnight.
+    _TIME_EXTRACT = {
+        "hour": (3_600_000_000, 24),
+        "minute": (60_000_000, 60),
+        "second": (1_000_000, 60),
+    }
+
     def time_extract_sql(self, lookup_type, sql, params):
         """
         Given a lookup_type of 'hour', 'minute', or 'second', return the SQL
         that extracts a value from the given time field field_name.
         """
-        return self.datetime_extract_sql(lookup_type, sql, params, tzname=None)
+        # TimeField is stored as Int64 microseconds since midnight (YDB has no
+        # native time type), so DateTime::Get* -- which operate on temporal
+        # types -- cannot be used; compute the component with integer arithmetic
+        # on the microseconds value instead (issue #81).
+        unit = self._TIME_EXTRACT.get(lookup_type)
+        if unit is None:
+            msg = f"Unsupported lookup type for TimeField: {lookup_type}"
+            raise ValueError(msg)
+        divisor, modulus = unit
+        return f"(({sql}) / {divisor} % {modulus})", params
 
     # TODO: Double check
     def last_executed_query(self, cursor, sql, params):


### PR DESCRIPTION
Closes #81

## Problem

`TimeField` is stored as `Int64` microseconds since midnight (YDB has no native time type). `time_extract_sql` delegated to `datetime_extract_sql`, emitting `DateTime::GetHour`/`GetMinute`/`GetSecond` — YQL functions that operate on temporal types, not on the `Int64` column — so `__hour`/`__minute`/`__second` lookups raised.

## Fix

Compute the component with integer arithmetic on the stored microseconds value:

- `hour = v / 3600000000 % 24`
- `minute = v / 60000000 % 60`
- `second = v / 1000000 % 60`

Removes the `django_test_skips` entry for the `lookup.test_timefield` hour/minute/second tests, adds a `TimeField` lookup regression test (`AlarmModel`), and updates the `TimeField` row in `docs/SUPPORT.md`.

Part of the #51 non-beta release backlog.