### PR TITLE
fix: drop constant GROUP BY terms and order by aggregate aliases

### DIFF
--- a/tests/aggregates/test_aggregate.py
+++ b/tests/aggregates/test_aggregate.py
@@ -1,9 +1,12 @@
 from django.db.models import Avg
 from django.db.models import Count
+from django.db.models import ExpressionWrapper
+from django.db.models import IntegerField
 from django.db.models import Max
 from django.db.models import Min
 from django.db.models import Q
 from django.db.models import Sum
+from django.db.models import Value
 from django.test import TransactionTestCase
 
 from .models import Car
@@ -486,3 +489,51 @@ class TestAggregates(TransactionTestCase):
         self.assertIn("COUNT", sql)
         self.assertIn("SUM", sql)
         self.assertIn("CASE WHEN", sql)
+
+
+class TestAggregateCompilerGaps(TransactionTestCase):
+    """Database function/aggregate gaps surfaced by conformance (issue #80)."""
+
+    databases = {"default"}
+
+    def setUp(self):
+        Car.objects.bulk_create(
+            [
+                Car(id=1, make="Toyota", model="Camry", color="Red",
+                    max_speed=200, price=25000, year=2020, in_stock=True),
+                Car(id=2, make="Toyota", model="Corolla", color="Blue",
+                    max_speed=190, price=22000, year=2021, in_stock=True),
+                Car(id=3, make="Honda", model="Civic", color="Black",
+                    max_speed=210, price=24000, year=2022, in_stock=True),
+            ]
+        )
+
+    def test_group_by_drops_constant_expression(self):
+        # A constant annotation alongside an aggregate puts a constant in
+        # GROUP BY, which YQL rejects ("Unable to GROUP BY constant
+        # expression"); the constant term must be dropped from the clause.
+        car = (
+            Car.objects.annotate(
+                combined=ExpressionWrapper(
+                    Value(3) * Value(4), output_field=IntegerField()
+                ),
+                review_count=Count("id"),
+            )
+            .order_by("id")
+            .first()
+        )
+        self.assertEqual(car.combined, 12)
+        self.assertEqual(car.review_count, 1)
+
+    def test_order_by_selected_aggregate(self):
+        # YQL cannot ORDER BY an aggregate directly ("Unable to ORDER BY
+        # aggregated values"); ordering must reference the selected alias.
+        rows = list(
+            Car.objects.values("make")
+            .annotate(n=Count("id"))
+            .order_by("n", "make")
+        )
+        self.assertEqual(
+            [(r["make"], r["n"]) for r in rows],
+            [("Honda", 1), ("Toyota", 2)],
+        )

--- a/ydb_backend/models/sql/compiler.py
+++ b/ydb_backend/models/sql/compiler.py
@@ -344,10 +344,14 @@ class SQLCompiler(_ParamTypingMixin, SQLCompiler):
         # SELECT DISTINCT it resolves ORDER BY against the projected columns
         # only (issue #93), and it cannot ORDER BY an aggregate in a GROUP BY
         # query ("Unable to ORDER BY aggregated values", issue #80).
+        # Keyed by SQL with a list of (params, alias): different select
+        # expressions can compile to the same SQL text (e.g. constants that both
+        # render "%s") yet differ in their bound params, so the params are kept
+        # to disambiguate which alias an order-by term maps to.
         select_aliases = {}
-        for _, (s_sql, _), s_alias in self.select:
+        for _, (s_sql, s_params), s_alias in self.select:
             if s_alias:
-                select_aliases.setdefault(s_sql, s_alias)
+                select_aliases.setdefault(s_sql, []).append((s_params, s_alias))
         distinct = self.query.distinct and not self.query.distinct_fields
         # YDB rejects "ORDER BY N" (ordinal position reference, a Django 5.x
         # optimisation via PositionRef). Re-compile affected entries with the
@@ -379,8 +383,17 @@ class SQLCompiler(_ParamTypingMixin, SQLCompiler):
             ):
                 match = self.ordering_parts.search(entry_sql)
                 base = match[1] if match else entry_sql
-                alias = select_aliases.get(base)
-                if alias:
+                # Match on params too so a same-SQL-but-different-params select
+                # column is not aliased to the wrong one.
+                alias = next(
+                    (
+                        a
+                        for s_params, a in select_aliases.get(base, ())
+                        if s_params == entry_params
+                    ),
+                    None,
+                )
+                if alias is not None:
                     direction = entry_sql[len(base):]
                     entry_sql = f"{self.connection.ops.quote_name(alias)}{direction}"
                     entry_params = []

--- a/ydb_backend/models/sql/compiler.py
+++ b/ydb_backend/models/sql/compiler.py
@@ -338,15 +338,17 @@ def _get_data_type(fields):
 class SQLCompiler(_ParamTypingMixin, SQLCompiler):
     def get_order_by(self):
         result = super().get_order_by()
-        # Under SELECT DISTINCT, YQL resolves ORDER BY against the projected
-        # output columns only. Map each selected column's SQL to its alias so an
-        # order-by term that re-emits a select expression can reference that
-        # alias instead of a base column the projection has dropped (issue #93).
-        distinct_aliases = {}
-        if self.query.distinct and not self.query.distinct_fields:
-            for _, (s_sql, _), s_alias in self.select:
-                if s_alias:
-                    distinct_aliases.setdefault(s_sql, s_alias)
+        # Map each selected column's SQL to its alias so an order-by term that
+        # re-emits a select expression can reference that alias instead. YQL
+        # rejects ordering by such an expression directly in two cases: under
+        # SELECT DISTINCT it resolves ORDER BY against the projected columns
+        # only (issue #93), and it cannot ORDER BY an aggregate in a GROUP BY
+        # query ("Unable to ORDER BY aggregated values", issue #80).
+        select_aliases = {}
+        for _, (s_sql, _), s_alias in self.select:
+            if s_alias:
+                select_aliases.setdefault(s_sql, s_alias)
+        distinct = self.query.distinct and not self.query.distinct_fields
         # YDB rejects "ORDER BY N" (ordinal position reference, a Django 5.x
         # optimisation via PositionRef). Re-compile affected entries with the
         # underlying source expression so the actual column name is emitted.
@@ -365,18 +367,19 @@ class SQLCompiler(_ParamTypingMixin, SQLCompiler):
             else:
                 entry_sql, entry_params = o_sql, o_params
             entry_is_ref = is_ref
-            if distinct_aliases:
-                # Strip the trailing direction (ASC/DESC) to match the bare
-                # select SQL. The keys are full select expressions, so a plain
-                # alias reference (already safe under DISTINCT) never matches;
-                # only a re-emitted expression -- whether a non-ref term or a
-                # PositionRef expanded just above -- is rewritten to its alias.
-                # Drop the now-duplicated params (bound by the select column)
-                # and mark the entry as a reference so get_extra_select() does
-                # not re-add the alias as an extra projected column.
+            # Rewrite to the select alias only when YQL needs it: a DISTINCT
+            # projection, or an aggregate term. The keys are full select
+            # expressions, so a plain alias reference never matches; only a
+            # re-emitted expression (a non-ref term or a PositionRef expanded
+            # just above) is rewritten. Drop the now-duplicated params (bound by
+            # the select column) and mark the entry as a reference so
+            # get_extra_select() does not re-add the alias as an extra column.
+            if select_aliases and (
+                distinct or getattr(resolved, "contains_aggregate", False)
+            ):
                 match = self.ordering_parts.search(entry_sql)
                 base = match[1] if match else entry_sql
-                alias = distinct_aliases.get(base)
+                alias = select_aliases.get(base)
                 if alias:
                     direction = entry_sql[len(base):]
                     entry_sql = f"{self.connection.ops.quote_name(alias)}{direction}"
@@ -480,6 +483,12 @@ class SQLCompiler(_ParamTypingMixin, SQLCompiler):
 
                 grouping = []
                 for g_sql, g_params in group_by:
+                    # YQL rejects "GROUP BY <constant>" (issue #80). A grouping
+                    # term with no column reference (column names are
+                    # backtick-quoted) is constant -- the same value for every
+                    # row -- so it does not partition the result and is dropped.
+                    if "`" not in g_sql:
+                        continue
                     grouping.append(g_sql)
                     params.extend(g_params)
                     param_types += [None] * len(g_params)


### PR DESCRIPTION
Refs #80

Two aggregate-query gaps surfaced by the `annotations` conformance module:

## GROUP BY a constant expression

A constant annotation alongside an aggregate — e.g. `annotate(combined=ExpressionWrapper(Value(3) * Value(4)), c=Count(...))` — emits the constant into `GROUP BY`, which YQL rejects (`Unable to GROUP BY constant expression`). Grouping terms with no column reference are now dropped: a constant is the same value for every row, so it does not partition the result.

## ORDER BY an aggregate

Ordering by a selected aggregate re-emits the aggregate (`ORDER BY COUNT(...)`), which YQL rejects (`Unable to ORDER BY aggregated values`). The order-by term now references the select alias instead, generalising the `SELECT DISTINCT` alias rewrite from #93 to also cover aggregate terms.

Adds regression tests for both.

### Not covered

- `.alias()` (non-selected) aggregate ordering — `values(...).alias(c=Count(...)).order_by("c")` puts the aggregate in `ORDER BY` but not the `SELECT`, so there is no alias to reference; fixing it would require wrapping the grouped query in a subquery. Left for a follow-up.
- The `PI()` mapping from #80 already landed (`Math::Pi()`); `Random()` / `CURRENT_TIMESTAMP` did not reproduce as failures in the current suite (`Now` maps to `CurrentUtcTimestamp()`).