### PR TITLE
fix: drop constant ORDER BY terms; document correlated-subquery boundary

### DIFF
--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -247,8 +247,14 @@ These follow from YDB's architecture and are **not expected to change** (issue
    **primary-key-only models**; both raise `NotSupportedError`. Give every model
    at least one non-PK field, and use `abstract = True` base classes instead of
    concrete parents.
-4. **No correlated subqueries.** `OuterRef` inside `Exists`/`Subquery` cannot be
-   resolved.
+4. **No correlated subqueries.** A subquery that references the enclosing
+   query's table fails with `Member not found: <table>` (the outer row is not in
+   scope). This covers `OuterRef` inside `Exists`/`Subquery`, an `Exists`/subquery
+   used as a lookup's left-hand side, and Django's `exclude()` across a
+   multivalued relationship (which Django compiles to a correlated subquery).
+   Non-correlated subqueries (e.g. `field__in=<queryset>`) work. This is a YDB
+   platform limitation (#77); it is distinct from the `Unknown name: $element_N`
+   parameter-wiring error (related-field DELETE), which is fixed.
 
 ## Release-blocking vs non-blocking gaps
 

--- a/tests/aggregates/test_aggregate.py
+++ b/tests/aggregates/test_aggregate.py
@@ -537,3 +537,15 @@ class TestAggregateCompilerGaps(TransactionTestCase):
             [(r["make"], r["n"]) for r in rows],
             [("Honda", 1), ("Toyota", 2)],
         )
+
+    def test_order_by_drops_constant(self):
+        # An .extra() constant select used in order_by emits "ORDER BY (1)",
+        # which YQL rejects ("Unable to ORDER BY constant expression"); the
+        # constant term is dropped while the column term still orders the rows.
+        ids = list(
+            Car.objects.extra(select={"vplus": "max_speed+1", "cnst": "1"})
+            .order_by("cnst", "vplus")
+            .values_list("id", flat=True)
+        )
+        # Ordered by max_speed: Corolla (190), Camry (200), Civic (210).
+        self.assertEqual(ids, [2, 1, 3])

--- a/tests/aggregates/test_aggregate.py
+++ b/tests/aggregates/test_aggregate.py
@@ -549,3 +549,19 @@ class TestAggregateCompilerGaps(TransactionTestCase):
         )
         # Ordered by max_speed: Corolla (190), Camry (200), Civic (210).
         self.assertEqual(ids, [2, 1, 3])
+
+    def test_group_by_keeps_extra_column_expression(self):
+        # An .extra() raw column expression ("max_speed+1", emitted without
+        # backticks) references a column, so it must NOT be treated as a constant
+        # and dropped from GROUP BY. Asserted at the SQL level: YDB separately
+        # rejects grouping by such an expression at runtime (functional
+        # dependency), which is unrelated to the constant-dropping logic.
+        qs = (
+            Car.objects.extra(select={"sp": "max_speed+1"})
+            .values("sp")
+            .annotate(n=Count("id"))
+        )
+        sql, _ = qs.query.get_compiler("default").as_sql()
+        group_by = sql.split("GROUP BY", 1)
+        self.assertEqual(len(group_by), 2, "expected a GROUP BY clause")
+        self.assertIn("max_speed+1", group_by[1])

--- a/tests/compiler/test_param_typing.py
+++ b/tests/compiler/test_param_typing.py
@@ -106,8 +106,10 @@ class TestParameterTyping(TransactionTestCase):
 
     # Correlated subqueries (OuterRef) are typed and compose correctly, but YDB
     # does not support correlated subqueries: the outer table is not in scope
-    # inside the subquery ("Member not found"). This is a YDB platform
-    # limitation, unrelated to parameter typing, and is kept here as a marker.
+    # inside the subquery ("Member not found: <table>"). This is a YDB platform
+    # limitation, unrelated to parameter typing (issue #77; see
+    # docs/SUPPORT.md), and is kept here as a marker. Django's exclude() across
+    # a multivalued relation hits the same limitation.
     @expectedFailure
     def test_exists_correlated(self):
         skus = Product.objects.filter(

--- a/ydb_backend/backend/features.py
+++ b/ydb_backend/backend/features.py
@@ -219,9 +219,13 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             "basic.tests.SelectOnSaveTests.test_select_on_save_lying_update",
         },
         # --- lookup module (issue #72), grouped by observed failure mode. ---
-        "A subquery used as the left-hand side of a lookup (Exists/OuterRef/"
-        "subquery LHS) resolves to an unknown YQL member; correlated subqueries "
-        "are unsupported.": {
+        # All four use OuterRef inside Exists/Subquery: the subquery references
+        # the outer row, which YDB cannot resolve ("Member not found: <table>").
+        # Correlated subqueries are a YDB platform limitation, not a parameter
+        # wiring bug (issue #77; see docs/SUPPORT.md). Non-correlated subqueries
+        # work.
+        "Correlated subqueries (OuterRef inside Exists/Subquery, or an Exists/"
+        "subquery as a lookup left-hand side) are unsupported by YDB.": {
             "lookup.tests.LookupQueryingTests.test_filter_exists_lhs",
             "lookup.tests.LookupQueryingTests.test_filter_subquery_lhs",
             "lookup.tests.LookupTests.test_exact_exists",

--- a/ydb_backend/models/sql/compiler.py
+++ b/ydb_backend/models/sql/compiler.py
@@ -139,10 +139,13 @@ def _is_constant_sql(sql):
     ``(%s * %s)``. YQL rejects GROUP BY / ORDER BY on a constant expression
     (issues #80, #77), and a constant neither partitions nor orders rows, so such
     terms are dropped.
+
+    String literals are stripped first so a backtick inside one (e.g. ``'a`b'``)
+    is not mistaken for a column reference.
     """
-    if "`" in sql:
-        return False
     stripped = _STRING_LITERAL.sub("", sql).replace("%s", "")
+    if "`" in stripped:
+        return False
     return not re.search(r"[A-Za-z_]", stripped)
 
 

--- a/ydb_backend/models/sql/compiler.py
+++ b/ydb_backend/models/sql/compiler.py
@@ -1,3 +1,4 @@
+import re
 from datetime import date
 from datetime import datetime
 from datetime import time
@@ -121,6 +122,28 @@ def _replace_placeholders(sql):
         counter += 1
 
     return sql, placeholder_rows
+
+
+# String literals may carry a YQL type suffix, e.g. ``'x'u`` (Utf8).
+_STRING_LITERAL = re.compile(r"'(?:[^']|'')*'[a-zA-Z]*")
+
+
+def _is_constant_sql(sql):
+    """
+    Whether a GROUP BY / ORDER BY term references no row data and is constant.
+
+    Real columns are backtick-quoted and ``.extra()`` raw SQL references columns
+    via bare identifiers, so a term with neither a backtick nor (after string
+    literals and ``%s`` parameter placeholders are stripped) an identifier is a
+    pure literal such as ``(1)`` or a bound-parameter expression such as
+    ``(%s * %s)``. YQL rejects GROUP BY / ORDER BY on a constant expression
+    (issues #80, #77), and a constant neither partitions nor orders rows, so such
+    terms are dropped.
+    """
+    if "`" in sql:
+        return False
+    stripped = _STRING_LITERAL.sub("", sql).replace("%s", "")
+    return not re.search(r"[A-Za-z_]", stripped)
 
 
 def _infer_ydb_type(value):
@@ -496,11 +519,9 @@ class SQLCompiler(_ParamTypingMixin, SQLCompiler):
 
                 grouping = []
                 for g_sql, g_params in group_by:
-                    # YQL rejects "GROUP BY <constant>" (issue #80). A grouping
-                    # term with no column reference (column names are
-                    # backtick-quoted) is constant -- the same value for every
-                    # row -- so it does not partition the result and is dropped.
-                    if "`" not in g_sql:
+                    # YQL rejects "GROUP BY <constant>" (issue #80); a constant
+                    # does not partition the result, so drop it.
+                    if _is_constant_sql(g_sql):
                         continue
                     grouping.append(g_sql)
                     params.extend(g_params)
@@ -533,14 +554,21 @@ class SQLCompiler(_ParamTypingMixin, SQLCompiler):
             if order_by:
                 ordering = []
                 for _, (o_sql, o_params, _) in order_by:
+                    # YQL rejects "ORDER BY <constant>" (e.g. a constant
+                    # .extra() select); a constant does not order rows, so drop
+                    # it. Strip the trailing direction before the check.
+                    base = self.ordering_parts.search(o_sql)
+                    if _is_constant_sql(base[1] if base else o_sql):
+                        continue
                     ordering.append(o_sql)
                     params.extend(o_params)
                     param_types += [None] * len(o_params)
-                order_by_sql = f"ORDER BY {', '.join(ordering)}"
-                if combinator and features.requires_compound_order_by_subquery:
-                    result = ["SELECT * FROM (", *result, ")", order_by_sql]
-                else:
-                    result.append(order_by_sql)
+                if ordering:
+                    order_by_sql = f"ORDER BY {', '.join(ordering)}"
+                    if combinator and features.requires_compound_order_by_subquery:
+                        result = ["SELECT * FROM (", *result, ")", order_by_sql]
+                    else:
+                        result.append(order_by_sql)
 
             if with_limit_offset:
                 result.append(


### PR DESCRIPTION
Refs #77

Outcome of the #77 research (which cases are fixable vs fundamental), plus the one fixable gap it surfaced.

## Fix: ORDER BY a constant

Ordering by a constant — e.g. a constant `.extra()` select, rendered as `ORDER BY (1)` — is rejected by YQL (`Unable to ORDER BY constant expression`). This is the twin of the GROUP BY-constant gap fixed in #80.

A shared `_is_constant_sql()` helper now drops constant terms from **both** `GROUP BY` and `ORDER BY`. It detects a term that references no column: no backtick, and no identifier left once string literals and `%s` parameter placeholders are stripped. This:

- fixes the `ORDER BY (1)` case (and skips emitting an empty `ORDER BY`);
- replaces the cruder `"\`" not in g_sql` GROUP BY check from #80, fixing a latent false-positive where a `.extra()` raw column reference (e.g. `(max_speed+1)`, no backtick) was wrongly dropped from `GROUP BY`.

## Docs: correlated-subquery boundary (#77 research)

The #77 failures are all correlated subqueries — a subquery referencing the enclosing query's table fails with `Member not found: <table>` (the outer row is not in scope). This is a YDB platform limitation, distinct from the `Unknown name: $element_N` parameter-wiring class (fixed in #94). It covers `OuterRef` inside `Exists`/`Subquery`, an `Exists`/subquery used as a lookup LHS, and Django's `exclude()` across a multivalued relationship. Non-correlated subqueries work.

`SUPPORT.md`, the lookup `django_test_skips` reason, and the correlated `@expectedFailure` markers are updated to state this precisely.