### PR TITLE
fix: emit a LIMIT before OFFSET for open-ended slices

### DIFF
--- a/tests/compiler/test_select.py
+++ b/tests/compiler/test_select.py
@@ -1,5 +1,7 @@
 from django.test import TransactionTestCase
 
+from .models import Product
+from .models import ProductReview
 from .models import SimpleItem
 
 
@@ -43,3 +45,57 @@ class TestExists(TransactionTestCase):
         self.assertFalse(
             SimpleItem.objects.filter(category="electronics", quantity=0).exists()
         )
+
+
+class TestSlicedSubquery(TransactionTestCase):
+    """
+    Slicing a subquery emits LIMIT/OFFSET inside it. YQL rejects a bare OFFSET
+    (it must follow a LIMIT), so qs[N:] -- an offset with no upper bound -- needs
+    an explicit unbounded LIMIT, else "mismatched input 'OFFSET'".
+    """
+
+    databases = {"default"}
+
+    def setUp(self):
+        product = Product.objects.create(
+            sku="P1", name="p", category="c", price=1, stock=1
+        )
+        # Ratings 0..4; ids ascend with creation order.
+        self.ids = [
+            ProductReview.objects.create(product=product, rating=r).id
+            for r in range(5)
+        ]
+
+    def _filter_in(self, sliced):
+        return set(
+            ProductReview.objects.filter(id__in=sliced).values_list(
+                "id", flat=True
+            )
+        )
+
+    def test_limit_only_subquery(self):
+        # [:2] -> LIMIT 2: the two highest ids.
+        sub = ProductReview.objects.order_by("-id")[:2]
+        self.assertEqual(self._filter_in(sub), set(self.ids[3:]))
+
+    def test_limit_and_offset_subquery(self):
+        # [1:3] -> LIMIT 2 OFFSET 1: skip the highest id, take the next two.
+        sub = ProductReview.objects.order_by("-id")[1:3]
+        self.assertEqual(self._filter_in(sub), {self.ids[2], self.ids[3]})
+
+    def test_offset_only_subquery(self):
+        # [2:] -> OFFSET with no upper bound: a default LIMIT is applied (and a
+        # warning emitted); drops the two highest ids.
+        sub = ProductReview.objects.order_by("-id")[2:]
+        with self.assertWarns(UserWarning):
+            self.assertEqual(self._filter_in(sub), set(self.ids[:3]))
+
+    def test_offset_only_outer_query(self):
+        # The same on a top-level query, not just a subquery.
+        with self.assertWarns(UserWarning):
+            got = list(
+                ProductReview.objects.order_by("-id")[2:].values_list(
+                    "id", flat=True
+                )
+            )
+        self.assertEqual(got, self.ids[:3][::-1])

--- a/tests/compiler/test_select.py
+++ b/tests/compiler/test_select.py
@@ -50,8 +50,8 @@ class TestExists(TransactionTestCase):
 class TestSlicedSubquery(TransactionTestCase):
     """
     Slicing a subquery emits LIMIT/OFFSET inside it. YQL rejects a bare OFFSET
-    (it must follow a LIMIT), so qs[N:] -- an offset with no upper bound -- needs
-    an explicit unbounded LIMIT, else "mismatched input 'OFFSET'".
+    (it must follow a LIMIT), so qs[N:] -- an offset with no upper bound -- gets
+    a default LIMIT (and a warning), else "mismatched input 'OFFSET'".
     """
 
     databases = {"default"}
@@ -99,3 +99,8 @@ class TestSlicedSubquery(TransactionTestCase):
                 )
             )
         self.assertEqual(got, self.ids[:3][::-1])
+
+    def test_empty_slice(self):
+        # qs[5:5] is LIMIT 0 (limit is 0, not "no limit"): it must return
+        # nothing, not fall into the offset-default path and return rows.
+        self.assertEqual(list(ProductReview.objects.order_by("-id")[5:5]), [])

--- a/ydb_backend/backend/operations.py
+++ b/ydb_backend/backend/operations.py
@@ -362,7 +362,9 @@ class DatabaseOperations(BaseDatabaseOperations):
         """
         limit, offset = self._get_limit_offset_params(low_mark, high_mark)
         parts = []
-        if limit:
+        if limit is not None:
+            # ``is not None`` keeps an explicit ``LIMIT 0`` (e.g. qs[:0] or
+            # qs[5:5]) instead of treating it as "no limit".
             parts.append(f"LIMIT {limit}")
         elif offset:
             warnings.warn(

--- a/ydb_backend/backend/operations.py
+++ b/ydb_backend/backend/operations.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import warnings
 
 from django.db.backends.base.operations import BaseDatabaseOperations
 from django.db.models.functions import Now
@@ -345,6 +346,37 @@ class DatabaseOperations(BaseDatabaseOperations):
         Return the value to use for the LIMIT when we are wanting "LIMIT
         infinity". Return None if the limit clause can be omitted in this case.
         """
+
+    # Default LIMIT applied to an OFFSET with no upper bound (see
+    # limit_offset_sql). YQL has no "unbounded" limit -- a huge value makes the
+    # server try to materialise that many rows (deadline/execution errors) -- so
+    # a finite default is used and a warning is emitted.
+    _UNBOUNDED_OFFSET_LIMIT = 1000
+
+    def limit_offset_sql(self, low_mark, high_mark):
+        """
+        Return a LIMIT/OFFSET clause. YQL rejects a bare ``OFFSET`` (it must
+        follow a ``LIMIT``), so a slice with an offset but no upper bound -- e.g.
+        ``qs[2:]``, including inside an ``IN`` subquery -- gets a default LIMIT
+        and warns, since there is no real upper bound to emit.
+        """
+        limit, offset = self._get_limit_offset_params(low_mark, high_mark)
+        parts = []
+        if limit:
+            parts.append(f"LIMIT {limit}")
+        elif offset:
+            warnings.warn(
+                "YDB requires a LIMIT before OFFSET; an open-ended slice "
+                f"(e.g. qs[{offset}:]) has no upper bound, so a default "
+                f"LIMIT {self._UNBOUNDED_OFFSET_LIMIT} is applied. Add an "
+                "explicit upper bound (qs[start:stop]) to avoid truncating the "
+                "result.",
+                stacklevel=2,
+            )
+            parts.append(f"LIMIT {self._UNBOUNDED_OFFSET_LIMIT}")
+        if offset:
+            parts.append(f"OFFSET {offset}")
+        return " ".join(parts)
 
     def quote_name(self, name):
         """


### PR DESCRIPTION
YQL rejects a bare `OFFSET` (it must follow a `LIMIT`), so an open-ended slice — `qs[N:]`, including inside an `IN` subquery — failed with `mismatched input 'OFFSET' expecting ')'`. (Surfaced while researching #77 in the `queries` conformance module: `test_ordered_subselect`, `test_slice_subquery_and_query`, `test_sliced_delete`.)

## Fix

`limit_offset_sql` now applies a default `LIMIT` and emits a warning when an offset has no upper bound.

A huge sentinel `LIMIT` (e.g. `2**63-1`) is **not** usable: YDB tries to materialise that many rows, producing deadline/execution errors rather than treating it as "unbounded". So a finite default (`1000`) is used, and the warning tells the user to add an explicit upper bound (`qs[start:stop]`) to avoid silently truncating the result.

Behaviour is unchanged for every other case — `LIMIT n` and `LIMIT n OFFSET m` are emitted exactly as before; only the previously-failing bare-`OFFSET` path changes.

Adds sliced-subquery regression tests: `LIMIT`-only, `LIMIT`+`OFFSET`, and the open-ended `OFFSET` path (which also asserts the warning).