### PR TITLE
ci: add SLO key-value workload for ydb-slo-action

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.django-src
+.ruff_cache
+.pytest_cache
+**/__pycache__
+*.pyc
+docs
+conformance
+examples
+poetry.lock

--- a/.github/workflows/slo.yml
+++ b/.github/workflows/slo.yml
@@ -1,0 +1,112 @@
+name: SLO
+
+# SLO runs are expensive (a 6-node YDB cluster + chaos), so they are opt-in:
+# add the "SLO" label to a PR to trigger a run. The label is removed when the
+# run finishes, so re-adding it starts a fresh run.
+on:
+  pull_request:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      github_issue:
+        description: "PR number to post the SLO report to"
+        required: false
+      workload_duration:
+        description: "Workload duration in seconds"
+        required: false
+        default: "600"
+
+permissions:
+  contents: read
+
+jobs:
+  ydb-slo-test:
+    name: Run SLO (${{ matrix.scenario }})
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.label.name == 'SLO' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # kv: point get/upsert; query: range scan + transactional read-modify-write.
+        scenario: [kv, query]
+    steps:
+      - name: Install docker tooling (yq, buildx, compose)
+        run: |
+          YQ_VERSION=v4.48.2
+          BUILDX_VERSION=0.30.1
+          COMPOSE_VERSION=2.40.3
+
+          sudo curl -L "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -o /usr/local/bin/yq
+          sudo chmod +x /usr/local/bin/yq
+
+          sudo mkdir -p /usr/local/lib/docker/cli-plugins
+          sudo curl -fLo /usr/local/lib/docker/cli-plugins/docker-buildx \
+            "https://github.com/docker/buildx/releases/download/v${BUILDX_VERSION}/buildx-v${BUILDX_VERSION}.linux-amd64"
+          sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-buildx
+
+          sudo curl -fLo /usr/local/lib/docker/cli-plugins/docker-compose \
+            "https://github.com/docker/compose/releases/download/v${COMPOSE_VERSION}/docker-compose-linux-x86_64"
+          sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Build workload image
+        run: docker build -f tests/slo/Dockerfile -t django-ydb-slo:current .
+
+      - name: Run SLO workload
+        uses: ydb-platform/ydb-slo-action/init@v2
+        timeout-minutes: 30
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_issue: ${{ github.event.inputs.github_issue }}
+          workload_name: django-${{ matrix.scenario }}
+          workload_duration: ${{ github.event.inputs.workload_duration || '600' }}
+          workload_current_ref: ${{ github.head_ref || github.ref_name }}
+          workload_current_image: django-ydb-slo:current
+          workload_current_command: --scenario ${{ matrix.scenario }}
+          # Single-version run: there is no baseline workload image to compare
+          # against, so the baseline profile stays off.
+          disable_compose_profiles: workload-baseline
+
+  ydb-slo-report:
+    name: Publish YDB SLO report
+    needs: ydb-slo-test
+    # Still publish whatever was collected if the workload run failed mid-way,
+    # but stay skipped for unrelated labels.
+    if: ${{ always() && (github.event_name == 'workflow_dispatch' || github.event.label.name == 'SLO') }}
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Publish report
+        uses: ydb-platform/ydb-slo-action/report@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_run_id: ${{ github.run_id }}
+          github_issue: ${{ github.event.inputs.github_issue }}
+
+  remove-slo-label:
+    name: Remove SLO label
+    needs: [ydb-slo-test, ydb-slo-report]
+    if: ${{ always() && github.event_name == 'pull_request' && github.event.label.name == 'SLO' }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Remove SLO label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api -X DELETE \
+            "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/SLO" \
+            || echo "Label 'SLO' was not present"

--- a/docs/RETRIES.md
+++ b/docs/RETRIES.md
@@ -1,0 +1,167 @@
+Retries
+===
+
+> See [Transactions](TRANSACTIONS.md#retries-and-conflicts) for how conflicts
+> arise. This page covers the retry helper shipped with the backend.
+
+YDB is a distributed database: nodes restart, fail over and rebalance, and
+optimistic `SERIALIZABLE` transactions abort on conflict. These are **expected,
+retryable** conditions, and the YDB SDK already knows exactly which errors are
+retryable and how to back off.
+
+Two layers retry for you automatically:
+
+- The **YDB driver / session pool** routes around dead nodes (endpoint
+  discovery) and re-acquires sessions.
+- **ydb-dbapi** retries **autocommit** statements (each is its own transaction
+  and safe to replay) using the SDK policy.
+
+What is **not** retried automatically is the body of an open
+`transaction.atomic()`: a single statement inside an interactive transaction
+cannot be replayed transparently — the whole transaction must restart, which
+only your code can do. Django itself never retries queries. That gap is what
+`ydb_backend.retry` fills.
+
+## The helper
+
+`ydb_backend.retry` provides a decorator and a function:
+
+```python
+from django.db import transaction
+from ydb_backend.retry import retry_ydb_errors, retry_ydb_operation
+
+# Decorator — guard a whole operation / transaction:
+@retry_ydb_errors(idempotent=True)
+def reserve_seat(event_id, user_id):
+    with transaction.atomic():
+        event = Event.objects.get(pk=event_id)
+        event.free_seats -= 1
+        event.save(update_fields=["free_seats"])
+        Ticket.objects.create(event=event, user_id=user_id)
+
+# Or wrap a callable inline:
+def charge():
+    with transaction.atomic():
+        ...
+
+retry_ydb_operation(charge, idempotent=True)
+```
+
+### How it works
+
+A failing call is **unwrapped back to its `ydb.issues.*` cause** and handed to
+the SDK's own `ydb.retry_operation_sync`. This means the set of retriable
+errors, the idempotency rules and the backoff schedule all come **straight from
+the SDK** — when the SDK updates its retry policy, this helper inherits it with
+no changes here. Nothing about YDB's error classification is duplicated in the
+backend.
+
+- A **non-retriable** error (e.g. a constraint or query error) and **running out
+  of retries** re-raise the **original Django exception** (`OperationalError`,
+  `IntegrityError`, …), not a raw SDK error.
+- An error with **no YDB cause** is never retried.
+- Between attempts the connection is cleaned up with Django's own
+  `close_if_unusable_or_obsolete()`: a genuinely dead connection is dropped so
+  the next attempt reconnects, while a healthy pooled one is kept (a single lost
+  node does not force a full reconnect).
+
+### Idempotency
+
+Pass `idempotent=True` only when re-running the operation is safe. YDB
+distinguishes errors where the transaction definitely did **not** apply (e.g.
+`Aborted` — always retriable) from those where the outcome is **unknown** (e.g.
+`Undetermined` — retried only when you declare the operation idempotent).
+
+Safe to mark idempotent:
+
+- reads;
+- primary-key `UPSERT` (same key, same result);
+- a read-modify-write transaction that **re-reads** inside `atomic()` before
+  writing (replaying re-reads the current state).
+
+Leave it `False` (the default) for operations that must not run twice on an
+ambiguous outcome (e.g. a blind, non-keyed `INSERT`, or a counter increment that
+is not derived from a fresh read).
+
+### Tuning
+
+By default the SDK policy is used (10 retries, exponential backoff). Override
+with a `ydb.RetrySettings`:
+
+```python
+import ydb
+from ydb_backend.retry import retry_ydb_errors
+
+@retry_ydb_errors(retry_settings=ydb.RetrySettings(max_retries=5, idempotent=True))
+def f():
+    ...
+```
+
+When `retry_settings` is given it owns all knobs, so set `idempotent` on it
+(the `idempotent=` argument is only used to build the default settings).
+
+To stop a worker from blocking for a long time on a dead node, bound both the
+retry count and each attempt's deadline. `max_retries`, `backoff_ceiling` and
+`backoff_slot_duration` live on `ydb.RetrySettings`; the per-attempt timeout is a
+`ydb.BaseRequestSettings().with_timeout(seconds)` installed on the connection
+(`connection.connection.set_ydb_request_settings(...)`, e.g. from a
+`connection_created` receiver). Worst-case time on one operation is then roughly
+`max_retries * (request_timeout + backoff)`.
+
+## API
+
+`retry_ydb_operation(func, *, idempotent=False, retry_settings=None, using="default", on_error=None)`
+
+- `func` — zero-argument callable to run (and retry).
+- `idempotent` — allow retrying errors that are only safe to replay for
+  idempotent operations. Used only when `retry_settings` is not supplied.
+- `retry_settings` — a `ydb.RetrySettings`; overrides `idempotent` and the
+  backoff.
+- `using` — connection alias whose hygiene is managed between attempts
+  (`close_if_unusable_or_obsolete()`); pass `None` to skip.
+- `on_error(exc)` — optional hook called with the caught Django exception after
+  each failed attempt (e.g. for logging or metrics).
+
+`retry_ydb_errors(*, idempotent=False, retry_settings=None, using="default", on_error=None)`
+is the decorator form with the same parameters.
+
+## Observing retries
+
+To count or log retries, set `on_ydb_error_callback` on a `ydb.RetrySettings` —
+the SDK calls it for every YDB error it sees while retrying (in this helper and
+in the driver's own retry of autocommit statements):
+
+```python
+import ydb
+from django.db.backends.signals import connection_created
+
+retries = 0
+
+def _count(_err):
+    global retries
+    retries += 1
+
+settings = ydb.RetrySettings(on_ydb_error_callback=_count)
+
+# Count the driver's autocommit retries by installing the settings on every
+# new connection:
+def _install(sender, connection, **kwargs):
+    inner = getattr(connection, "connection", None)
+    if inner is not None:
+        inner.set_ydb_retry_settings(settings)
+
+connection_created.connect(_install)
+
+# ...and pass the same settings to retry_ydb_errors/retry_ydb_operation to count
+# transaction retries too.
+```
+
+This is how the SLO workload reports `sdk_retry_attempts_total`.
+
+## What not to wrap
+
+- **Autocommit statements** are already retried by ydb-dbapi — wrapping a single
+  `Model.objects.get(...)` outside a transaction is redundant (harmless, but
+  unnecessary).
+- **Operations with non-idempotent side effects** (sending email, charging a
+  card) should not be retried unless those effects are guarded for replay.

--- a/docs/TRANSACTIONS.md
+++ b/docs/TRANSACTIONS.md
@@ -49,17 +49,17 @@ aborted with a retryable error, surfaced as `django.db.OperationalError`
 - **`atomic()` blocks are not retried automatically.** Neither the driver (it
   cannot replay a multi-statement interactive transaction) nor Django (which has
   no built-in transaction retry) retries them. Retrying is the application's
-  responsibility: catch `OperationalError` and re-run the whole block.
+  responsibility — use the [`ydb_backend.retry`](RETRIES.md) helper, which
+  retries only YDB-retriable errors using the native SDK policy:
 
 ```python
-from django.db import OperationalError, transaction
+from django.db import transaction
+from ydb_backend.retry import retry_ydb_errors
 
-for attempt in range(3):
-    try:
-        with transaction.atomic():
-            ...  # reads and writes
-        break
-    except OperationalError:
-        if attempt == 2:
-            raise
+@retry_ydb_errors(idempotent=True)  # the transaction re-reads before writing
+def transfer():
+    with transaction.atomic():
+        ...  # reads and writes
 ```
+
+See [Retries](RETRIES.md) for idempotency rules, tuning and the full API.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,6 +58,7 @@ Documentation
    CONTRIB
    OPERATIONS
    TRANSACTIONS
+   RETRIES
 
 
 Indices and tables

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.ruff]
-exclude = [".venv", ".git", ".github/scripts", "__pycache__", "build", "dist", "venv", "examples", "docs"]
+exclude = [".venv", ".git", ".github/scripts", "__pycache__", "build", "dist", "venv", "examples", "docs", "tests/slo"]
 line-length = 88
 target-version = "py310"
 src = ["ydb_backend", "tests"]

--- a/tests/backends/ydb/test_retry.py
+++ b/tests/backends/ydb/test_retry.py
@@ -1,0 +1,142 @@
+"""Tests for ydb_backend.retry.
+
+These verify the retry decision is delegated to the native YDB SDK policy:
+SDK-retriable issues (e.g. Aborted/Overloaded) are retried, non-retriable ones
+(e.g. BadRequest) are not, and idempotency gating (Undetermined) is honoured —
+without this module hard-coding any of those rules. No database is needed.
+"""
+
+import ydb
+from django.db import OperationalError
+from django.db import ProgrammingError
+from django.test import SimpleTestCase
+from ydb_backend.retry import retry_ydb_errors
+from ydb_backend.retry import retry_ydb_operation
+from ydb_backend.retry import unwrap_ydb_error
+
+
+def _wrapped(django_exc_cls, ydb_issue):
+    """Build a Django DB exception whose cause is a ``ydb.issues.*`` error,
+    mirroring the ydb-dbapi -> Django wrapping chain."""
+    exc = django_exc_cls("wrapped")
+    exc.__cause__ = ydb_issue
+    return exc
+
+
+def _settings(max_retries, *, idempotent=False):
+    # Zero the slow backoff slot so retried tests don't actually sleep; Aborted
+    # additionally yields no sleep at all in the SDK.
+    return ydb.RetrySettings(
+        max_retries=max_retries,
+        backoff_slot_duration=0.0,
+        idempotent=idempotent,
+    )
+
+
+class UnwrapYdbErrorTests(SimpleTestCase):
+    def test_follows_cause_chain(self):
+        issue = ydb.issues.Aborted("tli")
+        exc = _wrapped(OperationalError, issue)
+        self.assertIs(unwrap_ydb_error(exc), issue)
+
+    def test_follows_original_error_attribute(self):
+        class FakeDBAPIError(Exception):
+            pass
+
+        issue = ydb.issues.Unavailable("down")
+        err = FakeDBAPIError("x")
+        err.original_error = issue
+        self.assertIs(unwrap_ydb_error(err), issue)
+
+    def test_returns_none_without_ydb_cause(self):
+        self.assertIsNone(unwrap_ydb_error(ValueError("nope")))
+
+
+class RetryOperationTests(SimpleTestCase):
+    def test_retries_retriable_then_succeeds(self):
+        calls = {"n": 0}
+
+        def op():
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise _wrapped(OperationalError, ydb.issues.Aborted("tli"))
+            return "ok"
+
+        result = retry_ydb_operation(op, retry_settings=_settings(5))
+        self.assertEqual(result, "ok")
+        self.assertEqual(calls["n"], 3)
+
+    def test_non_retriable_is_not_retried(self):
+        calls = {"n": 0}
+
+        def op():
+            calls["n"] += 1
+            raise _wrapped(ProgrammingError, ydb.issues.BadRequest("bad sql"))
+
+        with self.assertRaises(ProgrammingError):
+            retry_ydb_operation(op, retry_settings=_settings(5))
+        self.assertEqual(calls["n"], 1)
+
+    def test_exhaustion_raises_original_django_exception(self):
+        def op():
+            raise _wrapped(OperationalError, ydb.issues.Overloaded("busy"))
+
+        with self.assertRaises(OperationalError):
+            retry_ydb_operation(op, retry_settings=_settings(2))
+
+    def test_undetermined_retried_only_when_idempotent(self):
+        non_idem = {"n": 0}
+
+        def op_non_idem():
+            non_idem["n"] += 1
+            raise _wrapped(OperationalError, ydb.issues.Undetermined("maybe"))
+
+        with self.assertRaises(OperationalError):
+            retry_ydb_operation(
+                op_non_idem, retry_settings=_settings(3, idempotent=False)
+            )
+        self.assertEqual(non_idem["n"], 1)
+
+        idem = {"n": 0}
+
+        def op_idem():
+            idem["n"] += 1
+            raise _wrapped(OperationalError, ydb.issues.Undetermined("maybe"))
+
+        with self.assertRaises(OperationalError):
+            retry_ydb_operation(op_idem, retry_settings=_settings(2, idempotent=True))
+        self.assertEqual(idem["n"], 3)  # first attempt + 2 retries
+
+    def test_non_database_error_propagates_without_retry(self):
+        calls = {"n": 0}
+
+        def op():
+            calls["n"] += 1
+            raise ValueError("logic bug")
+
+        with self.assertRaises(ValueError):
+            retry_ydb_operation(op, retry_settings=_settings(5))
+        self.assertEqual(calls["n"], 1)
+
+    def test_on_error_called_per_failed_attempt(self):
+        seen = []
+
+        def op():
+            raise _wrapped(OperationalError, ydb.issues.Aborted("tli"))
+
+        with self.assertRaises(OperationalError):
+            retry_ydb_operation(op, retry_settings=_settings(2), on_error=seen.append)
+        self.assertEqual(len(seen), 3)  # first attempt + 2 retries
+
+    def test_retriable_decorator(self):
+        calls = {"n": 0}
+
+        @retry_ydb_errors(retry_settings=_settings(5))
+        def op():
+            calls["n"] += 1
+            if calls["n"] < 2:
+                raise _wrapped(OperationalError, ydb.issues.Aborted("tli"))
+            return 42
+
+        self.assertEqual(op(), 42)
+        self.assertEqual(calls["n"], 2)

--- a/tests/slo/Dockerfile
+++ b/tests/slo/Dockerfile
@@ -1,0 +1,39 @@
+# syntax=docker/dockerfile:1
+#
+# SLO workload image for ydb-slo-action. Build from the repository root:
+#
+#   docker build -f tests/slo/Dockerfile -t django-ydb-slo:current .
+#
+# The action runs this image inside the YDB cluster network and injects
+# YDB_ENDPOINT / YDB_DATABASE / WORKLOAD_* / OTEL_* env vars (see
+# tests/slo/docker-entrypoint.sh and tests/slo/README.md). Any
+# `workload_current_command` arguments are appended to the `run` subcommand.
+#
+# hdrhistogram is built from sdist, so gcc/libc6-dev are needed.
+
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends gcc libc6-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# 1. Install the backend under test (pulls Django + ydb-dbapi).
+COPY pyproject.toml README.md ./
+COPY ydb_backend/ ydb_backend/
+RUN pip install --no-cache-dir .
+
+# 2. Workload-only dependencies.
+COPY tests/slo/requirements.txt tests/slo/requirements.txt
+RUN pip install --no-cache-dir -r tests/slo/requirements.txt
+
+# 3. Workload source + entrypoint.
+COPY tests/slo/src tests/slo/src
+COPY tests/slo/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/tests/slo/README.md
+++ b/tests/slo/README.md
@@ -1,0 +1,144 @@
+# SLO workload (Django key-value)
+
+SLO testing runs an application against a YDB cluster while a chaos monkey kills,
+pauses, restarts and network-partitions nodes, then measures throughput,
+availability and latency. This workload drives YDB **through the Django ORM and
+`ydb_backend`** — the code path this repository ships — so the numbers reflect
+the backend, not a raw SDK.
+
+It plugs into [`ydb-platform/ydb-slo-action`](https://github.com/ydb-platform/ydb-slo-action);
+see `.github/workflows/slo.yml`.
+
+## The model
+
+A single `KeyValue` model (`tests/slo/src/slo_app/models.py`): an explicit
+integer primary key plus a small payload (`payload_str`, `payload_double`,
+`payload_timestamp`). `create` seeds keys `1..records`, and the workload keeps
+every key within that range so reads always hit an existing row.
+
+Read and write jobs run in parallel at independent rates (`--read-rps` /
+`--write-rps`, `--read-threads` / `--write-threads`); `--scenario` selects what
+each does. Each logical operation is recorded once, tagged with the number of
+retries the YDB SDK actually performed (see [Retries](#retries) below).
+
+## Scenarios
+
+Both scenarios use the same model and the same `read` / `write` operation types
+(so the standard report metrics apply); they differ in what those operations do
+and which backend code path they exercise.
+
+### `kv` (default) — point key-value access
+
+The classic key-value workload: single-row access by primary key, one round-trip
+per operation.
+
+| Op | ORM call | Statement | Backend path exercised |
+|----|----------|-----------|------------------------|
+| read | `KeyValue.objects.get(pk=key)` | `SELECT … WHERE id = $k` | SELECT compiler, point read |
+| write | `KeyValue.objects.upsert(row)` | `UPSERT INTO slo_kv (…) VALUES (…)` | `YDBManager` / `UpsertQuery`, native UPSERT |
+
+The write is a blind UPSERT — it never reads first, so outside of node failures
+it needs no retries. This is the hot path with minimal per-op overhead.
+
+### `query` — range scan + transactional read-modify-write
+
+A heavier, more ORM-shaped mix that exercises what a real application hits beyond
+plain key lookups.
+
+| Op | ORM call | Statement | Backend path exercised |
+|----|----------|-----------|------------------------|
+| read | `KeyValue.objects.filter(id__gte=lo, id__lt=lo+scan_range).order_by("-payload_double")[:scan_limit]` | `SELECT … WHERE id >= $lo AND id < $hi ORDER BY payload_double DESC LIMIT n` | range predicate + `ORDER BY` + `LIMIT` compiler |
+| write | `with transaction.atomic(): obj = …get(pk=key); obj.save(update_fields=…)` | `BEGIN; SELECT … WHERE id = $k; UPDATE slo_kv SET … WHERE id = $k; COMMIT` | interactive transaction (begin/commit) + UPDATE compiler |
+
+The read is a bounded range scan with ordering and a top-N limit. The write is a
+read-modify-write inside `transaction.atomic()`: an interactive transaction
+spanning a SELECT and an UPDATE — several round-trips, and subject to YDB
+optimistic-concurrency conflicts, so under load/chaos it retries where the `kv`
+UPSERT does not. Tune the scan shape with `--scan-range` (PK window width) and
+`--scan-limit` (rows returned).
+
+## Metrics
+
+Metrics are pushed via OTLP/HTTP to the Prometheus receiver the action provides.
+Names follow the action contract:
+
+```
+sdk_operations_total{operation_type, operation_status, ref}
+sdk_retry_attempts_total{operation_type, ref}
+sdk_operation_latency_p50_seconds{operation_type, operation_status, ref}
+sdk_operation_latency_p95_seconds{operation_type, operation_status, ref}
+sdk_operation_latency_p99_seconds{operation_type, operation_status, ref}
+```
+
+Latency percentiles are computed client-side per push window (HdrHistogram) and
+emitted as gauges. The `ref` label (current vs baseline) comes from
+`WORKLOAD_REF`.
+
+## CLI
+
+Run as a directory module — `python tests/slo/src <subcommand>`:
+
+| Subcommand | Purpose |
+|------------|---------|
+| `create`   | Create the `slo_kv` table (if absent) and seed `records` rows |
+| `run`      | Run the read/write workload and push metrics |
+| `cleanup`  | Drop the `slo_kv` table |
+
+`run` flags: `--scenario {kv,query}`, `--time`, `--read-rps`, `--write-rps`,
+`--read-threads`, `--write-threads`, `--report-period` (ms), `--max-retries`,
+`--request-timeout` (s), `--scan-range`/`--scan-limit` (query scenario),
+`--otlp-endpoint`. Key-space size is shared via `--records` / `SLO_RECORDS`.
+
+The workflow runs both scenarios as a matrix (`django-kv`, `django-query`).
+
+## Retries
+
+Retries are handled where each kind needs them, and the workload counts the
+**real** retries the YDB SDK performs (not just its own loop):
+
+- **Autocommit** statements (point reads, UPSERTs, range scans) are retried by
+  the YDB driver inside ydb-dbapi. The workload installs a `ydb.RetrySettings`
+  on every connection (via the `connection_created` signal) whose
+  `on_ydb_error_callback` increments a per-thread retry counter — so the
+  driver's retries are observed.
+- The **interactive transaction** (read-modify-write) is the one path the driver
+  cannot replay, so it is wrapped with `@retry_ydb_errors` from
+  `ydb_backend.retry` — the same way application code should guard its own
+  transactions. It shares the same `RetrySettings`, so its retries are counted
+  too.
+
+`@retry_ydb_errors` delegates the retry/backoff decision to the native YDB SDK
+policy (only YDB-retriable errors are retried) and applies Django's connection
+hygiene between attempts. See [docs/RETRIES.md](../../docs/RETRIES.md).
+
+The retry budget is bounded so a chaos-stuck worker fails fast instead of
+hanging: `--max-retries` plus a per-attempt `--request-timeout` (installed on the
+connection as `BaseRequestSettings().with_timeout(...)`) and a capped backoff —
+worst-case ≈ `max_retries * (request_timeout + backoff)`.
+
+## Connection
+
+Connection details come from the environment the action injects, with local
+fallbacks:
+
+| Variable | Default | Used for |
+|----------|---------|----------|
+| `YDB_ENDPOINT` | `grpc://localhost:2136` | `HOST` / `PORT` |
+| `YDB_DATABASE` | `/local` | `DATABASE` |
+| `WORKLOAD_DURATION` | `600` | default `--time` |
+| `WORKLOAD_REF` | `current` | `ref` metric label |
+| `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` / `OTEL_EXPORTER_OTLP_ENDPOINT` | — | OTLP push |
+
+## Run locally
+
+Against the repo's docker-compose YDB (`docker compose up -d --wait`):
+
+```shell
+docker build -f tests/slo/Dockerfile -t django-ydb-slo:local .
+
+# create + 30s run, metrics disabled (no OTLP endpoint set)
+docker run --rm --network host \
+  -e YDB_ENDPOINT=grpc://localhost:2136 -e YDB_DATABASE=/local \
+  django-ydb-slo:local sh -c \
+  'python /app/tests/slo/src create && python /app/tests/slo/src run --time 30'
+```

--- a/tests/slo/docker-entrypoint.sh
+++ b/tests/slo/docker-entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Workload entrypoint used by ydb-slo-action.
+#
+# The action launches this image (for the current and, optionally, baseline
+# workloads) and injects the connection + workload env vars. Schema prep runs
+# first, then the timed workload. Anything passed after the script name comes
+# from `workload_current_command` / `workload_baseline_command` and is appended
+# to the `run` subcommand (e.g. --read-rps 2000 --write-rps 200).
+set -e
+
+DURATION="${WORKLOAD_DURATION:-600}"
+SRC=/app/tests/slo/src
+
+echo "[slo] create + seed..."
+# Idempotent; a parallel baseline container may have prepared the table already.
+python "$SRC" create || echo "[slo] create exited non-zero (treated as prepared)" >&2
+
+echo "[slo] run (duration=${DURATION}s)..."
+exec python "$SRC" run --time "$DURATION" "$@"

--- a/tests/slo/requirements.txt
+++ b/tests/slo/requirements.txt
@@ -1,0 +1,8 @@
+# Extra dependencies for the SLO workload container (on top of the installed
+# django-ydb-backend, which brings in Django and ydb-dbapi).
+hdrhistogram==0.10.3
+
+# OpenTelemetry OTLP/HTTP metric exporter (requires Python >= 3.9).
+opentelemetry-api==1.39.1
+opentelemetry-sdk==1.39.1
+opentelemetry-exporter-otlp-proto-http==1.39.1

--- a/tests/slo/src/__main__.py
+++ b/tests/slo/src/__main__.py
@@ -1,0 +1,181 @@
+"""Entry point for the Django key-value SLO workload.
+
+Subcommands:
+
+* ``create``  — create the ``slo_kv`` table (if absent) and seed initial rows
+* ``run``     — run the read/write workload and push OTLP metrics
+* ``cleanup`` — drop the ``slo_kv`` table
+
+Connection details come from ``YDB_ENDPOINT`` / ``YDB_DATABASE`` (see
+settings.py). Run as ``python tests/slo/src <subcommand> [options]``.
+"""
+
+import argparse
+import logging
+import os
+import sys
+
+logger = logging.getLogger("slo")
+
+# Scenario names for the argparse choices. The implementations live in jobs.py,
+# which can only be imported after django.setup().
+_SCENARIOS = ("kv", "query")
+
+
+def _env_int(name, default):
+    try:
+        return int(os.environ.get(name, "") or default)
+    except ValueError:
+        return default
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(description="Django YDB SLO workload")
+    parser.add_argument("--debug", action="store_true", help="Verbose logging")
+    parser.add_argument(
+        "--records",
+        type=int,
+        default=_env_int("SLO_RECORDS", 1000),
+        help="Size of the key space (primary keys 1..records)",
+    )
+
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    create = sub.add_parser("create", help="Create and seed the table")
+    create.add_argument("--batch-size", type=int, default=100)
+
+    sub.add_parser("cleanup", help="Drop the table")
+
+    run = sub.add_parser("run", help="Run the workload")
+    run.add_argument(
+        "--scenario",
+        choices=sorted(_SCENARIOS),
+        default=os.environ.get("SLO_SCENARIO", "kv"),
+        help="kv: point get/upsert; query: range scan + transactional RMW",
+    )
+    run.add_argument(
+        "--time",
+        type=int,
+        default=_env_int("WORKLOAD_DURATION", 600),
+        help="Run duration in seconds",
+    )
+    run.add_argument("--scan-range", type=int, default=50, help="query: PK scan width")
+    run.add_argument("--scan-limit", type=int, default=10, help="query: rows per scan")
+    run.add_argument("--read-rps", type=int, default=1000)
+    run.add_argument("--write-rps", type=int, default=100)
+    run.add_argument("--read-threads", type=int, default=8)
+    run.add_argument("--write-threads", type=int, default=4)
+    run.add_argument(
+        "--report-period", type=int, default=1000, help="Metrics push period [ms]"
+    )
+    run.add_argument(
+        "--max-retries",
+        type=int,
+        default=5,
+        help="Max YDB retries per operation (bounds how long a worker can block)",
+    )
+    run.add_argument(
+        "--request-timeout",
+        type=float,
+        default=3.0,
+        help="Per-attempt request timeout in seconds",
+    )
+    run.add_argument(
+        "--otlp-endpoint",
+        type=str,
+        default="",
+        help="OTLP metrics endpoint; usually taken from OTEL_* env vars",
+    )
+    return parser
+
+
+def cmd_create(args):
+    from django.db import connection
+
+    from slo_app.models import KeyValue
+
+    table = KeyValue._meta.db_table
+    if table not in connection.introspection.table_names():
+        logger.info("Creating table %s", table)
+        try:
+            with connection.schema_editor() as editor:
+                editor.create_model(KeyValue)
+        except Exception:
+            # A parallel (baseline) container may win the race — tolerate it.
+            if table not in connection.introspection.table_names():
+                raise
+            logger.warning("Table %s already created concurrently", table)
+    else:
+        logger.info("Table %s already exists", table)
+
+    _seed(KeyValue, args.records, args.batch_size)
+
+
+def _seed(model, records, batch_size):
+    from generator import make_row
+
+    logger.info("Seeding %d rows (batch=%d)", records, batch_size)
+    seeded = 0
+    for start in range(1, records + 1, batch_size):
+        rows = [make_row(k) for k in range(start, min(start + batch_size, records + 1))]
+        model.objects.bulk_upsert(rows)
+        seeded += len(rows)
+    logger.info("Seeded %d rows", seeded)
+
+
+def cmd_cleanup(args):
+    from django.db import connection
+
+    from slo_app.models import KeyValue
+
+    table = KeyValue._meta.db_table
+    if table in connection.introspection.table_names():
+        logger.info("Dropping table %s", table)
+        with connection.schema_editor() as editor:
+            editor.delete_model(KeyValue)
+    else:
+        logger.info("Table %s does not exist; nothing to drop", table)
+
+
+def cmd_run(args):
+    from jobs import JobManager
+    from metrics import create_metrics
+
+    metrics = create_metrics(args.otlp_endpoint)
+    logger.info(
+        "Running workload: scenario=%s time=%ds records=%d read(rps=%d,threads=%d) "
+        "write(rps=%d,threads=%d)",
+        args.scenario,
+        args.time,
+        args.records,
+        args.read_rps,
+        args.read_threads,
+        args.write_rps,
+        args.write_threads,
+    )
+    try:
+        JobManager(args, metrics).run()
+    finally:
+        metrics.shutdown()
+    logger.info("Workload finished")
+
+
+def main():
+    args = build_parser().parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.debug else logging.INFO,
+        format="%(asctime)s %(levelname)-8s %(name)s %(message)s",
+    )
+
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+    import django
+
+    django.setup()
+
+    handlers = {"create": cmd_create, "run": cmd_run, "cleanup": cmd_cleanup}
+    handlers[args.command](args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/slo/src/generator.py
+++ b/tests/slo/src/generator.py
@@ -1,0 +1,21 @@
+"""Random row generation for the key-value workload."""
+
+import random
+import string
+from datetime import datetime
+from datetime import timezone
+
+
+def random_string(min_len=20, max_len=40):
+    length = random.randint(min_len, max_len)
+    return "".join(random.choices(string.ascii_lowercase, k=length))
+
+
+def make_row(key):
+    """Build a KeyValue row dict for the given primary key."""
+    return {
+        "id": key,
+        "payload_str": random_string(),
+        "payload_double": random.random(),
+        "payload_timestamp": datetime.now(timezone.utc),
+    }

--- a/tests/slo/src/jobs.py
+++ b/tests/slo/src/jobs.py
@@ -1,0 +1,228 @@
+"""Read / write / metrics jobs for the SLO workload.
+
+Every operation runs through the Django ORM on top of ydb_backend. Retries are
+handled where each kind actually needs them:
+
+- **autocommit** statements (point reads, UPSERTs, range scans) are retried by
+  the YDB driver itself (ydb-dbapi wraps them in the session pool's retry);
+- the **interactive transaction** (read-modify-write) is the one path the driver
+  cannot replay, so it is guarded with ``@retry_ydb_errors`` — exactly how
+  application code should guard its own transactions.
+
+Both retry layers share one ``ydb.RetrySettings`` whose ``on_ydb_error_callback``
+counts every YDB error the SDK retries, so the metric reflects the *real* driver
+retries (not just our own). The connection-level settings are installed on each
+new connection via the ``connection_created`` signal.
+
+Two scenarios are available (``--scenario``):
+
+``kv`` (default) — point key-value access: ``get(pk)`` / native ``upsert``.
+``query`` — primary-key range scan + ``ORDER BY``/``LIMIT`` reads, and a
+transactional read-modify-write.
+"""
+
+import logging
+import random
+import threading
+import time
+from datetime import datetime
+from datetime import timezone
+
+import ydb
+from django.db import connections
+from django.db import transaction
+from django.db.backends.signals import connection_created
+
+from generator import make_row
+from generator import random_string
+from metrics import OP_TYPE_READ
+from metrics import OP_TYPE_WRITE
+from ratelimiter import SyncRateLimiter
+from slo_app.models import KeyValue
+from ydb_backend.retry import retry_ydb_errors
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CONN = "default"
+
+# Per-thread count of YDB errors the SDK retried during the current operation,
+# fed by RetrySettings.on_ydb_error_callback from both retry layers.
+_local = threading.local()
+
+
+def _count_ydb_retry(_err):
+    _local.retries = getattr(_local, "retries", 0) + 1
+
+
+# All workload operations are idempotent (point reads, key-keyed UPSERTs, range
+# scans, and the RMW transaction that re-reads before writing), so Undetermined
+# is retriable too. Shared by both retry layers; the callback does the counting.
+# Backoff is capped so a worker can't sleep for tens of seconds between attempts;
+# max_retries and the per-attempt timeout come from CLI args (configure_retries).
+_RETRY = ydb.RetrySettings(
+    idempotent=True,
+    on_ydb_error_callback=_count_ydb_retry,
+    backoff_ceiling=3,
+    backoff_slot_duration=0.3,
+)
+# Per-attempt deadline so a single call can't block on a dead node; replaced by
+# configure_retries() before the run.
+_request_settings = ydb.BaseRequestSettings()
+
+
+def configure_retries(args):
+    """Bound the retry budget from CLI args.
+
+    Worst-case time on one operation is about
+    ``max_retries * (request_timeout + backoff)`` — kept well under a minute so a
+    chaos-stuck worker fails fast and moves on instead of hanging.
+    """
+    global _request_settings
+    _RETRY.max_retries = args.max_retries
+    _RETRY.max_session_acquire_timeout = args.request_timeout
+    _request_settings = ydb.BaseRequestSettings().with_timeout(args.request_timeout)
+
+
+def _install_conn_settings(sender, connection, **kwargs):
+    # Configure every new ydb-dbapi connection so the driver's autocommit retries
+    # (and the transactional statements) use our bounded retry policy + per-attempt
+    # timeout, and run our counting callback.
+    inner = getattr(connection, "connection", None)
+    if inner is None:
+        return
+    if hasattr(inner, "set_ydb_retry_settings"):
+        inner.set_ydb_retry_settings(_RETRY)
+    if hasattr(inner, "set_ydb_request_settings"):
+        inner.set_ydb_request_settings(_request_settings)
+
+
+connection_created.connect(_install_conn_settings)
+
+
+# --- kv scenario: point access (autocommit — the driver retries these) ---------
+def _kv_read(args):
+    KeyValue.objects.get(pk=random.randint(1, args.records))
+
+
+def _kv_write(args):
+    KeyValue.objects.upsert(make_row(random.randint(1, args.records)))
+
+
+# --- query scenario ------------------------------------------------------------
+def _query_read(args):
+    lo = random.randint(1, max(1, args.records - args.scan_range))
+    # PK range scan, ordered by a non-key column, top-N — a different compiler
+    # path (range predicate + ORDER BY + LIMIT) than the kv point lookup.
+    rows = KeyValue.objects.filter(
+        id__gte=lo, id__lt=lo + args.scan_range
+    ).order_by("-payload_double")[: args.scan_limit]
+    list(rows)  # force evaluation
+
+
+# The interactive transaction is the one path the driver cannot retry for us, so
+# guard it with @retry_ydb_errors — the same way application code should. The
+# shared _RETRY settings make its retries count too.
+@retry_ydb_errors(retry_settings=_RETRY)
+def _query_write(args):
+    key = random.randint(1, args.records)
+    # SELECT the row, then UPDATE it inside one interactive transaction.
+    with transaction.atomic():
+        obj = KeyValue.objects.get(pk=key)
+        obj.payload_double = random.random()
+        obj.payload_str = random_string()
+        obj.payload_timestamp = datetime.now(timezone.utc)
+        obj.save(
+            update_fields=["payload_double", "payload_str", "payload_timestamp"]
+        )
+
+
+SCENARIOS = {
+    "kv": (_kv_read, _kv_write),
+    "query": (_query_read, _query_write),
+}
+
+
+def _execute(metrics, op_type, operation):
+    """Time one logical operation and record it once.
+
+    Retries happen below us (driver for autocommit, ``@retry_ydb_errors`` for the
+    transaction) and bump ``_local.retries`` through the callback. ``attempts`` is
+    ``retries + 1`` on success (first try plus retries), or the number of failed
+    attempts when the operation ultimately fails.
+    """
+    _local.retries = 0
+    start_ts = metrics.start(op_type)
+    error = None
+    try:
+        operation()
+    except Exception as err:  # noqa: BLE001 - recorded; the loop keeps running
+        error = err
+    retries = getattr(_local, "retries", 0)
+    attempts = max(retries + (0 if error else 1), 1)
+    metrics.stop(op_type, start_ts, attempts=attempts, error=error)
+
+
+class JobManager:
+    def __init__(self, args, metrics):
+        configure_retries(args)
+        self.args = args
+        self.metrics = metrics
+        self._stop = threading.Event()
+        self._read_op, self._write_op = SCENARIOS[args.scenario]
+
+    def run(self):
+        threads = []
+        threads += self._start_op_threads(
+            OP_TYPE_READ, self.args.read_threads, self.args.read_rps, self._read_op
+        )
+        threads += self._start_op_threads(
+            OP_TYPE_WRITE, self.args.write_threads, self.args.write_rps, self._write_op
+        )
+        threads.append(self._start_metrics_thread())
+
+        deadline = time.time() + self.args.time
+        try:
+            while time.time() < deadline and any(t.is_alive() for t in threads):
+                time.sleep(0.5)
+        finally:
+            self._stop.set()
+            for t in threads:
+                t.join()
+
+    def _start_op_threads(self, op_type, count, rps, operation):
+        # The RPS budget is shared across all threads of this operation type.
+        limiter = SyncRateLimiter.from_rps(rps)
+        threads = []
+        for i in range(count):
+            t = threading.Thread(
+                name=f"slo_{op_type}_{i}",
+                target=self._op_loop,
+                args=(op_type, limiter, operation),
+            )
+            t.start()
+            threads.append(t)
+        return threads
+
+    def _op_loop(self, op_type, limiter, operation):
+        try:
+            while not self._stop.is_set():
+                with limiter:
+                    _execute(self.metrics, op_type, lambda: operation(self.args))
+        finally:
+            connections[DEFAULT_CONN].close()
+
+    def _start_metrics_thread(self):
+        period_s = max(0.1, self.args.report_period / 1000.0)
+        t = threading.Thread(
+            name="slo_metrics", target=self._metrics_loop, args=(period_s,)
+        )
+        t.start()
+        return t
+
+    def _metrics_loop(self, period_s):
+        while not self._stop.is_set():
+            time.sleep(period_s)
+            try:
+                self.metrics.push()
+            except Exception:  # noqa: BLE001 - keep pushing despite a hiccup
+                logger.exception("metrics push failed")

--- a/tests/slo/src/metrics.py
+++ b/tests/slo/src/metrics.py
@@ -1,0 +1,251 @@
+"""OTLP metrics for the SLO workload.
+
+Implements the metric contract expected by ydb-slo-action: per-operation
+counters and pre-computed latency-percentile gauges, all carrying the ``ref``
+label (current vs baseline) plus ``operation_type`` and ``operation_status``.
+
+Latency percentiles (p50/p95/p99) are computed client-side per push window with
+an HdrHistogram and emitted as gauges — the action does not derive percentiles
+from histograms. Instrument names use dots; the Prometheus OTLP receiver maps
+them to ``sdk_operations_total`` / ``sdk_operation_latency_p50_seconds`` / etc.,
+which is what deploy/metrics.yaml queries.
+"""
+
+import logging
+import threading
+import time
+from abc import ABC
+from abc import abstractmethod
+from contextlib import contextmanager
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version
+from os import environ
+
+OP_TYPE_READ = "read"
+OP_TYPE_WRITE = "write"
+OP_STATUS_SUCCESS = "success"
+OP_STATUS_ERROR = "error"
+
+REF = environ.get("WORKLOAD_REF") or environ.get("REF") or "current"
+WORKLOAD = environ.get("WORKLOAD_NAME") or environ.get("WORKLOAD") or "django-kv"
+
+logger = logging.getLogger(__name__)
+
+
+def _backend_version():
+    try:
+        return version("django-ydb-backend")
+    except PackageNotFoundError:
+        return "0.0.0"
+
+
+class BaseMetrics(ABC):
+    @abstractmethod
+    def start(self, op_type):
+        ...
+
+    @abstractmethod
+    def stop(self, op_type, start_time, attempts=1, error=None):
+        ...
+
+    @abstractmethod
+    def push(self):
+        ...
+
+    def shutdown(self):
+        pass
+
+    @contextmanager
+    def measure(self, op_type):
+        start_ts = self.start(op_type)
+        error = None
+        attempts = 1
+        try:
+            yield
+        except BaseException as err:  # noqa: BLE001 - recorded then re-raised
+            error = err
+            raise
+        finally:
+            self.stop(op_type, start_ts, attempts=attempts, error=error)
+
+
+class DummyMetrics(BaseMetrics):
+    """No-op exporter used when no OTLP endpoint is configured."""
+
+    def start(self, op_type):
+        return time.time()
+
+    def stop(self, op_type, start_time, attempts=1, error=None):
+        return None
+
+    def push(self):
+        return None
+
+
+class OtlpMetrics(BaseMetrics):
+    _HDR_MIN_US = 1
+    _HDR_MAX_US = 60_000_000  # 60s
+    _HDR_SIG_FIGS = 3
+    _PERCENTILES = (("p50", 50.0), ("p95", 95.0), ("p99", 99.0))
+
+    def __init__(self, otlp_metrics_endpoint):
+        from hdrh.histogram import HdrHistogram
+        from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
+            OTLPMetricExporter,
+        )
+        from opentelemetry.sdk.metrics import MeterProvider
+        from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+        from opentelemetry.sdk.resources import Resource
+
+        self._HdrHistogram = HdrHistogram
+
+        resource = Resource.create(
+            {
+                "service.name": f"workload-{WORKLOAD}",
+                "service.instance.id": environ.get(
+                    "SLO_INSTANCE_ID", f"{REF}-{WORKLOAD}"
+                ),
+                "ref": REF,
+                "sdk": "django-ydb-backend",
+                "sdk_version": _backend_version(),
+                "workload": WORKLOAD,
+            }
+        )
+
+        exporter = OTLPMetricExporter(endpoint=otlp_metrics_endpoint)
+        reader = PeriodicExportingMetricReader(exporter)
+        self._provider = MeterProvider(resource=resource, metric_readers=[reader])
+        self._meter = self._provider.get_meter("ydb-slo")
+
+        self._operations_total = self._meter.create_counter(
+            name="sdk.operations.total",
+            description="Total number of logical operations attempted.",
+        )
+        self._operations_success_total = self._meter.create_counter(
+            name="sdk.operations.success.total",
+            description="Total number of successful operations.",
+        )
+        self._operations_failure_total = self._meter.create_counter(
+            name="sdk.operations.failure.total",
+            description="Total number of failed operations.",
+        )
+        self._retry_attempts_total = self._meter.create_counter(
+            name="sdk.retry.attempts.total",
+            description="Total number of attempts including the first one.",
+        )
+        self._errors = self._meter.create_counter(
+            name="sdk.errors.total",
+            description="Total number of errors by error type.",
+        )
+        self._pending = self._meter.create_up_down_counter(
+            name="sdk.pending.operations",
+            description="Number of in-flight operations.",
+        )
+        self._latency_gauges = {
+            name: self._meter.create_gauge(
+                name=f"sdk.operation.latency.{name}.seconds",
+                unit="s",
+                description=f"Operation latency {name} over the last push window.",
+            )
+            for name, _ in self._PERCENTILES
+        }
+
+        self._lock = threading.Lock()
+        self._hdr = {}
+
+    def _get_hdr(self, op_type, op_status):
+        key = (op_type, op_status)
+        hist = self._hdr.get(key)
+        if hist is None:
+            hist = self._HdrHistogram(
+                self._HDR_MIN_US, self._HDR_MAX_US, self._HDR_SIG_FIGS
+            )
+            self._hdr[key] = hist
+        return hist
+
+    def start(self, op_type):
+        self._pending.add(1, attributes={"ref": REF, "operation_type": op_type})
+        return time.time()
+
+    def stop(self, op_type, start_time, attempts=1, error=None):
+        duration = time.time() - start_time
+        duration_us = min(
+            max(int(duration * 1_000_000), self._HDR_MIN_US), self._HDR_MAX_US
+        )
+
+        op_status = OP_STATUS_SUCCESS if error is None else OP_STATUS_ERROR
+        base_attrs = {"ref": REF, "operation_type": op_type}
+        op_attrs = {**base_attrs, "operation_status": op_status}
+
+        self._retry_attempts_total.add(int(attempts), attributes=base_attrs)
+        self._pending.add(-1, attributes=base_attrs)
+        self._operations_total.add(1, attributes=op_attrs)
+
+        if error is not None:
+            self._errors.add(
+                1, attributes={**base_attrs, "error_type": type(error).__name__}
+            )
+            self._operations_failure_total.add(1, attributes=base_attrs)
+        else:
+            self._operations_success_total.add(1, attributes=base_attrs)
+
+        with self._lock:
+            self._get_hdr(op_type, op_status).record_value(duration_us)
+
+    def push(self):
+        with self._lock:
+            for (op_type, op_status), hist in self._hdr.items():
+                if hist.get_total_count() == 0:
+                    continue
+                attrs = {
+                    "ref": REF,
+                    "operation_type": op_type,
+                    "operation_status": op_status,
+                }
+                for name, percentile in self._PERCENTILES:
+                    value_s = hist.get_value_at_percentile(percentile) / 1_000_000
+                    self._latency_gauges[name].set(value_s, attributes=attrs)
+            for hist in self._hdr.values():
+                hist.reset()
+        self._provider.force_flush()
+
+    def shutdown(self):
+        try:
+            self.push()
+        finally:
+            self._provider.shutdown()
+
+
+def _resolve_metrics_endpoint(cli_endpoint):
+    """Resolve the OTLP metrics endpoint from env vars, then the CLI flag.
+
+    Order: ``OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`` (as-is), then
+    ``OTEL_EXPORTER_OTLP_ENDPOINT`` (with ``/v1/metrics`` appended), then the
+    explicit ``--otlp-endpoint`` value.
+    """
+    metrics_env = environ.get("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "").strip()
+    if metrics_env:
+        return metrics_env
+
+    base_env = environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "").strip()
+    if base_env:
+        base = base_env.rstrip("/")
+        if base.endswith("/v1/metrics"):
+            return base
+        return f"{base}/v1/metrics"
+
+    return (cli_endpoint or "").strip()
+
+
+def create_metrics(otlp_endpoint):
+    endpoint = _resolve_metrics_endpoint(otlp_endpoint)
+    if not endpoint:
+        logger.info("Metrics disabled (no OTLP endpoint); using DummyMetrics")
+        return DummyMetrics()
+
+    logger.info("Creating OTLP metrics exporter to: %s", endpoint)
+    try:
+        return OtlpMetrics(endpoint)
+    except Exception:
+        logger.exception("Failed to init OTLP exporter; falling back to DummyMetrics")
+        return DummyMetrics()

--- a/tests/slo/src/ratelimiter.py
+++ b/tests/slo/src/ratelimiter.py
@@ -1,0 +1,40 @@
+"""A lightweight, thread-safe rate limiter shared across worker threads."""
+
+import threading
+import time
+
+
+class SyncRateLimiter:
+    """Enforce a minimum interval between permits across all sharing threads.
+
+    Used as a context manager: ``with limiter: do_one_operation()``. With a
+    non-positive interval it is a no-op (run as fast as possible).
+    """
+
+    def __init__(self, min_interval_s):
+        self._min_interval_s = max(0.0, float(min_interval_s))
+        self._lock = threading.Lock()
+        self._next_allowed_ts = 0.0  # monotonic timestamp
+
+    @classmethod
+    def from_rps(cls, rps):
+        return cls(0.0 if rps <= 0 else 1.0 / rps)
+
+    def __enter__(self):
+        if self._min_interval_s <= 0.0:
+            return self
+
+        while True:
+            with self._lock:
+                now = time.monotonic()
+                if now >= self._next_allowed_ts:
+                    self._next_allowed_ts = now + self._min_interval_s
+                    return self
+                sleep_for = self._next_allowed_ts - now
+
+            # Sleep outside the lock so other threads can observe the schedule.
+            if sleep_for > 0:
+                time.sleep(sleep_for)
+
+    def __exit__(self, exc_type, exc, tb):
+        return False

--- a/tests/slo/src/settings.py
+++ b/tests/slo/src/settings.py
@@ -1,0 +1,49 @@
+"""Minimal Django settings for the SLO workload.
+
+The workload runs as a standalone container that the YDB SLO Action launches
+alongside the YDB cluster. Connection details come from the environment the
+action injects (``YDB_ENDPOINT`` / ``YDB_DATABASE``); for local runs they fall
+back to the docker-compose YDB on ``localhost:2136`` / ``/local``.
+"""
+
+import os
+
+
+def _endpoint_to_host_port(endpoint, default_host, default_port):
+    """Split ``grpc://ydb:2136`` (or ``ydb:2136``) into ``(host, port)``."""
+    if not endpoint:
+        return default_host, default_port
+    if "://" in endpoint:
+        endpoint = endpoint.split("://", 1)[1]
+    host, _, port = endpoint.partition(":")
+    return host or default_host, port or default_port
+
+
+_HOST, _PORT = _endpoint_to_host_port(
+    os.environ.get("YDB_ENDPOINT", ""), "localhost", "2136"
+)
+_DATABASE = os.environ.get("YDB_DATABASE", "/local")
+
+SECRET_KEY = "slo-workload-not-a-secret"  # noqa: S105
+USE_TZ = True
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+INSTALLED_APPS = ["slo_app"]
+
+DATABASES = {
+    "default": {
+        "ENGINE": "ydb_backend.backend",
+        "NAME": "slo",
+        "HOST": _HOST,
+        "PORT": str(_PORT),
+        "DATABASE": _DATABASE,
+        "OPTIONS": {
+            # Anonymous auth against the local/CI cluster, matching the
+            # reference workloads in ydb-slo-action.
+            "credentials": None,
+            # Keep gRPC channels probed so a chaos-killed node is dropped
+            # quickly instead of blocking a worker thread indefinitely.
+            "driver_config_kwargs": {"grpc_keep_alive_timeout": 10000},
+        },
+    }
+}

--- a/tests/slo/src/slo_app/apps.py
+++ b/tests/slo/src/slo_app/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class SloAppConfig(AppConfig):
+    name = "slo_app"
+    default_auto_field = "django.db.models.BigAutoField"

--- a/tests/slo/src/slo_app/models.py
+++ b/tests/slo/src/slo_app/models.py
@@ -1,0 +1,23 @@
+from django.db import models
+
+from ydb_backend.models.manager import YDBManager
+
+
+class KeyValue(models.Model):
+    """Key-value row exercised by the SLO workload.
+
+    The primary key is an explicit integer the workload controls, so reads can
+    target keys that are known to exist. Writes go through ``YDBManager.upsert``
+    (native YDB ``UPSERT INTO``), and reads through ``objects.get(pk=...)`` —
+    both run entirely on the Django ORM + ydb_backend code path under test.
+    """
+
+    id = models.BigIntegerField(primary_key=True)
+    payload_str = models.TextField()
+    payload_double = models.FloatField()
+    payload_timestamp = models.DateTimeField()
+
+    objects = YDBManager()
+
+    class Meta:
+        db_table = "slo_kv"

--- a/ydb_backend/retry.py
+++ b/ydb_backend/retry.py
@@ -1,0 +1,141 @@
+"""Retry helper that reuses the native YDB SDK retry policy.
+
+Django never retries queries, and ``ydb-dbapi`` only retries autocommit
+statements through its session pool — never the body of an open
+``transaction.atomic()`` (a single statement inside an interactive transaction
+cannot be replayed transparently; the whole transaction must restart). This
+module fills that gap **without re-implementing any policy**: a failing call is
+unwrapped back to its ``ydb.issues.*`` cause and handed to the SDK's own
+``ydb.retry_operation_sync``, so the set of retriable errors, the
+idempotency rules and the backoff all come straight from the SDK and track its
+updates automatically.
+
+The underlying ydb-dbapi connection holds a self-healing YDB driver + session
+pool, so a retry usually just needs to re-run on a fresh session the pool routes
+to a live node. Between attempts the connection is cleaned up with Django's own
+``close_if_unusable_or_obsolete()`` (the same hygiene Django applies at request
+boundaries): it health-checks only after a connection-affecting error and closes
+only a genuinely dead connection — a pool that merely lost one node is kept.
+
+Typical use is to wrap a whole transaction so an aborted/transient one is
+replayed::
+
+    from ydb_backend.retry import retry_ydb_errors
+
+    @retry_ydb_errors(idempotent=True)
+    def transfer():
+        with transaction.atomic():
+            ...
+
+To observe retries (e.g. for metrics), set ``on_ydb_error_callback`` on a
+``ydb.RetrySettings`` and pass it as ``retry_settings`` — the SDK calls it for
+every YDB error it sees while retrying.
+"""
+
+import functools
+
+import ydb
+from django.db import Error as DjangoDatabaseError
+from django.db import connections
+from django.db.utils import DEFAULT_DB_ALIAS
+
+
+def unwrap_ydb_error(exc):
+    """Return the underlying ``ydb.issues.Error`` of a wrapped exception.
+
+    The wrapping chain is ``django.db.*`` -> ``ydb_dbapi`` error (which keeps the
+    original on ``original_error``) -> ``ydb.issues.*``; both the ``__cause__``
+    links and the ``original_error`` attribute are followed. Returns ``None`` when
+    there is no YDB cause.
+    """
+    seen = set()
+    current = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, ydb.Error):
+            return current
+        original = getattr(current, "original_error", None)
+        if isinstance(original, ydb.Error):
+            return original
+        current = current.__cause__
+    return None
+
+
+def retry_ydb_operation(
+    func,
+    *,
+    idempotent=False,
+    retry_settings=None,
+    using=DEFAULT_DB_ALIAS,
+    on_error=None,
+):
+    """Call ``func`` and retry it under the native YDB retry policy.
+
+    Retry classification and backoff are delegated to ``ydb.retry_operation_sync``
+    by re-raising the unwrapped ``ydb.issues.*`` cause, so nothing here changes
+    when the SDK updates its policy. A non-retriable error (or running out of
+    retries) re-raises the original Django exception; an error with no YDB cause
+    is never retried.
+
+    ``idempotent`` allows retries for errors that are only safe to repeat (e.g.
+    ``Undetermined``) — pass it for reads and for transactions that re-read before
+    writing. It is honoured only when ``retry_settings`` is not supplied;
+    otherwise set ``idempotent`` on the passed ``ydb.RetrySettings``.
+
+    After each failed attempt the ``using`` connection is run through Django's
+    ``close_if_unusable_or_obsolete()`` so a dead connection is dropped before the
+    next attempt while a healthy pooled one is kept; pass ``using=None`` to skip
+    this. ``on_error`` is called with the caught Django exception after that, for
+    any extra handling.
+    """
+    settings = (
+        retry_settings
+        if retry_settings is not None
+        else ydb.RetrySettings(idempotent=idempotent)
+    )
+    captured = None
+
+    def callee():
+        nonlocal captured
+        try:
+            return func()
+        except DjangoDatabaseError as exc:
+            captured = exc
+            if using is not None:
+                connections[using].close_if_unusable_or_obsolete()
+            if on_error is not None:
+                on_error(exc)
+            ydb_error = unwrap_ydb_error(exc)
+            if ydb_error is None:
+                raise
+            raise ydb_error from exc
+
+    try:
+        return ydb.retry_operation_sync(callee, settings)
+    except ydb.Error:
+        # Retries exhausted or the error was non-retriable: surface the original
+        # Django exception type, not the unwrapped SDK error.
+        if captured is not None:
+            raise captured from captured.__cause__
+        raise
+
+
+def retry_ydb_errors(
+    *, idempotent=False, retry_settings=None, using=DEFAULT_DB_ALIAS, on_error=None
+):
+    """Decorator form of :func:`retry_ydb_operation`."""
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            return retry_ydb_operation(
+                lambda: func(*args, **kwargs),
+                idempotent=idempotent,
+                retry_settings=retry_settings,
+                using=using,
+                on_error=on_error,
+            )
+
+        return wrapper
+
+    return decorator


### PR DESCRIPTION
Adds SLO (Service Level Objective) testing for the backend via
[`ydb-platform/ydb-slo-action`](https://github.com/ydb-platform/ydb-slo-action),
so we can measure throughput, availability and latency under chaos as part of
release readiness.

Unlike the SDK/CLI reference workloads, this one drives YDB **through the Django
ORM and `ydb_backend`** — the code path this repository ships — so the numbers
reflect the backend, not a raw SDK.

### What runs

A single `KeyValue` model, two operation types in parallel:

- **read** — `KeyValue.objects.get(pk=key)` (SELECT compiler path)
- **write** — `KeyValue.objects.upsert(row)` (native YDB `UPSERT INTO` via `YDBManager`)

Keys stay within `1..records` so reads always hit a seeded row. Every logical
operation is retried on transient/connection errors (the broken connection is
dropped so the retry reconnects through endpoint discovery) and recorded once,
tagged with its attempt count.

### Metrics

Pushed via OTLP/HTTP to the action's Prometheus receiver, matching the action
contract (`sdk_operations_total`, `sdk_retry_attempts_total`,
`sdk_operation_latency_p{50,95,99}_seconds`), with the `ref`, `operation_type`
and `operation_status` labels. Latency percentiles are computed client-side per
push window (HdrHistogram) and emitted as gauges.

### How to trigger

SLO runs spin up a 6-node YDB cluster plus chaos, so they are opt-in: add the
**`SLO`** label to this PR. The workflow builds the workload image, runs the
action (current-only, no baseline yet), posts a report, and removes the label
when finished (re-add it to run again).

`tests/slo` is excluded from ruff (a standalone containerized app, like
`examples/`); `.dockerignore` keeps the build context small.

Part of release-readiness validation (#51).