### PR TITLE
ci(coverage): measure ydb_backend coverage and upload to Codecov

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,6 +57,20 @@ jobs:
       - name: Run tests
         run: poetry run coverage run tests/runtests.py
 
+      - name: Generate coverage report
+        run: poetry run coverage xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          flags: py${{ matrix.python-version }}-dj${{ matrix.django-version }}
+          name: py${{ matrix.python-version }}-dj${{ matrix.django-version }}
+          # Codecov outages should not fail the test gate; coverage is an
+          # informational signal, not a correctness check.
+          fail_ci_if_error: false
+
   conformance:
     # Runs Django's own bundled test suite against YDB as a required gate on
     # every supported Django version. `basic`/`lookup` must pass (gated by

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 django-ydb-backend
 ===
 
+[![codecov](https://codecov.io/gh/ydb-platform/django-ydb-backend/branch/main/graph/badge.svg)](https://codecov.io/gh/ydb-platform/django-ydb-backend)
+
 Django YDB Backend
 Overview
 This is a Django database backend for [YDB](https://ydb.tech/), a distributed SQL database system.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,33 @@
+# Codecov configuration.
+# https://docs.codecov.com/docs/codecovyml-reference
+
+coverage:
+  status:
+    project:
+      default:
+        # Compare against the base commit; allow a small dip so unrelated
+        # refactors don't turn the check red.
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+
+# Each test matrix entry uploads with its own py<ver>-dj<ver> flag; merge them
+# into the project total without requiring every flag on every commit.
+flag_management:
+  default_rules:
+    carryforward: true
+
+comment:
+  layout: "reach, diff, flags, files"
+  require_changes: false
+
+# Coverage is measured for the backend package only (see tool.coverage.run in
+# pyproject.toml); keep non-shipped code out of any report just in case.
+ignore:
+  - "tests"
+  - "examples"
+  - "docs"
+  - "conformance"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,22 @@ sphinx-copybutton = "^0.5.0"
 requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
 
+[tool.coverage.run]
+# Measure the backend package only; the test suite itself is the harness, not
+# the code under test.
+source = ["ydb_backend"]
+branch = true
+# Emit repo-relative paths so Codecov maps them onto the source tree regardless
+# of the absolute checkout location on the runner.
+relative_files = true
+omit = ["*/__pycache__/*"]
+
+[tool.coverage.report]
+show_missing = true
+
+[tool.coverage.xml]
+output = "coverage.xml"
+
 [tool.ruff]
 exclude = [".venv", ".git", ".github/scripts", "__pycache__", "build", "dist", "venv", "examples", "docs", "tests/slo"]
 line-length = 88


### PR DESCRIPTION
## Summary

The Tests workflow already ran the suite under `coverage run`, but the data was discarded — no report was generated or published. This wires up a real, measurable coverage metric via Codecov.

- **`pyproject.toml`** — `[tool.coverage.*]` config scoping measurement to the `ydb_backend` package, with branch coverage and `relative_files` so paths map onto the source tree on the runner.
- **`tests.yml`** — generate a Cobertura `coverage.xml` after the run and upload via `codecov/codecov-action@v5` (using the `CODECOV_TOKEN` secret). Each matrix entry uploads with a `py<ver>-dj<ver>` flag so per-version reports merge into the project total. `fail_ci_if_error: false` keeps a Codecov outage from failing the test gate.
- **`codecov.yml`** — project/patch status with `target: auto` and a 1% threshold, flag carryforward, and an informational PR comment.
- **`README.md`** — Codecov badge.