### PR TITLE
ci(coverage): upload coverage once per Django version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,17 +17,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # `coverage: true` marks one job per Django version (4.2/5.2/6.0) as the
+        # coverage source. Coverage only varies by Django version (e.g. the
+        # django.VERSION >= (6, 0) branch in creation.py), not by Python, so one
+        # job per Django version is enough; Codecov merges the three uploads.
         include:
           - python-version: "3.10"
             django-version: "4.2"
           - python-version: "3.12"
             django-version: "4.2"
+            coverage: true
           - python-version: "3.10"
             django-version: "5.2"
           - python-version: "3.12"
             django-version: "5.2"
+            coverage: true
           - python-version: "3.12"
             django-version: "6.0"
+            coverage: true
           - python-version: "3.13"
             django-version: "6.0"
 
@@ -55,18 +62,27 @@ jobs:
         run: docker compose up -d --wait
 
       - name: Run tests
-        run: poetry run coverage run tests/runtests.py
+        # Only instrument under coverage on the designated coverage jobs; the
+        # rest run the suite directly to avoid the instrumentation overhead.
+        run: |
+          if [ "${{ matrix.coverage }}" = "true" ]; then
+            poetry run coverage run tests/runtests.py
+          else
+            poetry run python tests/runtests.py
+          fi
 
       - name: Generate coverage report
+        if: ${{ matrix.coverage }}
         run: poetry run coverage xml
 
       - name: Upload coverage to Codecov
+        if: ${{ matrix.coverage }}
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
-          flags: py${{ matrix.python-version }}-dj${{ matrix.django-version }}
-          name: py${{ matrix.python-version }}-dj${{ matrix.django-version }}
+          flags: dj${{ matrix.django-version }}
+          name: dj${{ matrix.django-version }}
           # Codecov outages should not fail the test gate; coverage is an
           # informational signal, not a correctness check.
           fail_ci_if_error: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,13 @@
 # Codecov configuration.
 # https://docs.codecov.com/docs/codecovyml-reference
 
+codecov:
+  notify:
+    # One job per Django version (4.2/5.2/6.0) uploads coverage; wait for all
+    # three before computing statuses so the reported number doesn't flap as
+    # uploads trickle in.
+    after_n_builds: 3
+
 coverage:
   status:
     project:
@@ -14,8 +21,8 @@ coverage:
         target: auto
         threshold: 1%
 
-# Each test matrix entry uploads with its own py<ver>-dj<ver> flag; merge them
-# into the project total without requiring every flag on every commit.
+# One job per Django version uploads with a dj<ver> flag; merge them into the
+# project total without requiring every flag on every commit.
 flag_management:
   default_rules:
     carryforward: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -21,11 +21,12 @@ coverage:
         target: auto
         threshold: 1%
 
-# One job per Django version uploads with a dj<ver> flag; merge them into the
-# project total without requiring every flag on every commit.
+# One job per Django version uploads with a dj<ver> flag on every run, so there
+# is nothing to carry forward; keeping it off avoids dragging stale flags into
+# the session count.
 flag_management:
   default_rules:
-    carryforward: true
+    carryforward: false
 
 comment:
   layout: "reach, diff, flags, files"


### PR DESCRIPTION
## Summary

Follow-up to #106. Coverage only varies by **Django** version (e.g. the `django.VERSION >= (6, 0)` branch in `creation.py`), not by Python — so uploading from all six test matrix entries produced four redundant reports.

- **`tests.yml`** — a `coverage: true` matrix flag marks one job per Django version (4.2 / 5.2 / 6.0) as the coverage source. Those jobs run under `coverage` and upload with a `dj<ver>` flag; the rest run the suite directly (skipping the instrumentation overhead) and skip the upload. Codecov merges the three reports into the project total exactly as before.
- **`codecov.yml`** — `notify.after_n_builds: 3` so the reported number waits for all three uploads instead of flapping as they trickle in.

Net effect: 3 coverage uploads instead of 6, identical merged coverage number.