### PR TITLE
fix: map Random() to YQL and anchor order_by('?') (#80)

### DIFF
--- a/tests/compiler/test_functions.py
+++ b/tests/compiler/test_functions.py
@@ -1,6 +1,7 @@
 import math
 
 from django.db.models.functions import Pi
+from django.db.models.functions import Random
 from django.test import TransactionTestCase
 
 from .models import Book
@@ -13,3 +14,22 @@ class PiFunctionTest(TransactionTestCase):
         Book.objects.create(isbn="60", title="t", author="a", price=1)
         value = Book.objects.annotate(p=Pi()).get(isbn="60").p
         self.assertAlmostEqual(value, math.pi, places=5)
+
+
+class RandomFunctionTest(TransactionTestCase):
+    """Random() maps to YQL's Random(...) (no zero-arg RANDOM()); issue #80."""
+
+    def test_random_scalar(self):
+        # YQL's Random needs an argument; the backend anchors the scalar form on
+        # CurrentUtcTimestamp() so it yields a Double in [0, 1).
+        Book.objects.create(isbn="61", title="t", author="a", price=1)
+        value = Book.objects.annotate(r=Random()).get(isbn="61").r
+        self.assertGreaterEqual(value, 0.0)
+        self.assertLess(value, 1.0)
+
+    def test_random_ordering(self):
+        # order_by("?") orders by Random(<pk>, CurrentUtcTimestamp()); a
+        # query-constant random cannot be ordered by, so the pk anchors it.
+        for i in range(4):
+            Book.objects.create(isbn=f"7{i}", title="t", author="a", price=1)
+        self.assertEqual(len(list(Book.objects.order_by("?"))), 4)

--- a/ydb_backend/backend/features.py
+++ b/ydb_backend/backend/features.py
@@ -440,7 +440,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             "extra_regress.tests.ExtraRegressTests.test_regression_8039",
             "ordering.tests.OrderingTests.test_order_by_constant_value",
             "ordering.tests.OrderingTests.test_orders_nulls_first_on_filtered_subquery",
-            "ordering.tests.OrderingTests.test_random_ordering",
         },
         # --- Django 5.2/6.0-only failures (#72 cross-version triage). ---
         "Multi-table-inheritance saves run as TransactionTestCase (YDB has no "

--- a/ydb_backend/backend/operations.py
+++ b/ydb_backend/backend/operations.py
@@ -6,6 +6,7 @@ from django.db.backends.base.operations import BaseDatabaseOperations
 from django.db.models.functions import Lower
 from django.db.models.functions import Now
 from django.db.models.functions import Pi
+from django.db.models.functions import Random
 from django.db.models.functions import Substr
 from django.db.models.functions import Upper
 from django.db.models.lookups import PatternLookup
@@ -52,6 +53,24 @@ def _pi_as_ydb(self, compiler, connection, **extra_context):
 
 
 Pi.as_ydb = _pi_as_ydb
+
+
+def _random_as_ydb(self, compiler, connection, **extra_context):
+    # YQL has no zero-argument RANDOM() (Random's default template emits
+    # "RANDOM()", which YDB rejects with "requires at least 1 arguments").
+    # YQL's Random(args) returns a Double in [0, 1) keyed by its arguments;
+    # anchor it on CurrentUtcTimestamp() so the value changes per query run.
+    # (Ordering by '?' needs a per-row anchor instead and is handled in the
+    # compiler's get_order_by, since a query-constant random cannot be ordered.)
+    return self.as_sql(
+        compiler,
+        connection,
+        template="Random(CurrentUtcTimestamp())",
+        **extra_context,
+    )
+
+
+Random.as_ydb = _random_as_ydb
 
 
 def _upper_as_ydb(self, compiler, connection, **extra_context):

--- a/ydb_backend/models/sql/compiler.py
+++ b/ydb_backend/models/sql/compiler.py
@@ -14,7 +14,9 @@ from django.db import DatabaseError
 from django.db import IntegrityError
 from django.db import NotSupportedError
 from django.db import models
+from django.db.models.expressions import Col
 from django.db.models.expressions import RawSQL
+from django.db.models.functions import Random
 from django.db.models.lookups import Lookup
 from django.db.models.sql import compiler
 from django.db.models.sql.compiler import SQLAggregateCompiler
@@ -388,6 +390,16 @@ class SQLCompiler(_ParamTypingMixin, SQLCompiler):
         fixed = []
         for resolved, (o_sql, o_params, is_ref) in result:
             expr = getattr(resolved, "expression", None)
+            # order_by("?") compiles to OrderBy(Random()). YQL's Random is keyed
+            # by its arguments, so the scalar mapping (Random(CurrentUtcTimestamp())
+            # in operations) is a query-constant and "ORDER BY <constant>" is
+            # rejected. Re-anchor on the primary key so each row gets a distinct
+            # value, keeping CurrentUtcTimestamp() so the shuffle varies per run.
+            if isinstance(expr, Random):
+                anchor_sql, anchor_params = self._random_order_anchor()
+                entry_sql = f"Random({anchor_sql}, CurrentUtcTimestamp())"
+                fixed.append((resolved, (entry_sql, anchor_params, False)))
+                continue
             is_position_ref = (
                 expr is not None
                 and hasattr(expr, "ordinal")
@@ -429,6 +441,13 @@ class SQLCompiler(_ParamTypingMixin, SQLCompiler):
                     entry_is_ref = True
             fixed.append((resolved, (entry_sql, entry_params, entry_is_ref)))
         return fixed
+
+    def _random_order_anchor(self):
+        # Compile the primary-key column to use as a per-row anchor for a random
+        # ORDER BY (see get_order_by); a query-constant random cannot be ordered.
+        pk = self.query.get_meta().pk
+        alias = self.query.get_initial_alias()
+        return self.compile(Col(alias, pk))
 
     def as_sql(self, with_limits=True, with_col_aliases=False):
         """


### PR DESCRIPTION
Completes the last function-mapping gap from #80: `Random()`.

## Scalar `Random()`
YQL has no zero-argument `RANDOM()` (`"requires at least 1 arguments"`), and its `Random(args)` is keyed by its arguments. `Random.as_ydb` now emits `Random(CurrentUtcTimestamp())`, so the scalar form returns a `Double` in `[0, 1)` that changes per query run. Covers `annotate`/`filter`/`select`.

## `order_by('?')`
`order_by('?')` compiles to `OrderBy(Random())`, whose query-constant scalar form is rejected (`"Unable to ORDER BY constant expression"`). `get_order_by` now re-anchors it on the primary key — `Random(<pk>, CurrentUtcTimestamp())` — so each row gets a distinct value and the shuffle differs per run. `_random_order_anchor` falls back to leaving the order-by untouched when no single-table pk is available. The conformance `ordering.tests.OrderingTests.test_random_ordering` is un-skipped.

Closes #80