### PR TITLE
ci: enforce a CHANGELOG.md entry per PR and backfill since 0.0.1b6

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,32 @@
+name: Changelog
+
+# Every pull request must add a short entry to CHANGELOG.md so the unreleased
+# section is never empty at release time (the publish workflow reads the entries
+# above the latest "## <version> ##" header). PRs that need no entry — CI-only,
+# docs-only, chores — carry the "skip changelog" label to bypass this check.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require a CHANGELOG.md entry
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip changelog') }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          if gh api "repos/$REPO/pulls/$PR/files" --paginate --jq '.[].filename' \
+              | grep -qx 'CHANGELOG.md'; then
+            echo "CHANGELOG.md updated — OK."
+          else
+            echo "::error::This PR does not update CHANGELOG.md — add a short one-line entry at the top of CHANGELOG.md, or apply the 'skip changelog' label if no entry is needed."
+            exit 1
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ Tests use Django’s test runner through `tests/runtests.py`, not plain `pytest`
 
 ## Commit & Pull Request Guidelines
 
-Keep commits focused on one behavior or documentation change. Pull requests should include a concise summary, test commands run, and any YDB or Django compatibility notes. Link related issues when available and include screenshots only for documentation or example app UI changes.
+Keep commits focused on one behavior or documentation change. Pull requests should include a concise summary, test commands run, and any YDB or Django compatibility notes. Link related issues when available and include screenshots only for documentation or example app UI changes. Every pull request must add a short, one-line entry to the top of `CHANGELOG.md` describing the change (a CI check enforces this); apply the `skip changelog` label for pull requests that need no entry, such as CI-only or docs-only changes.
 
 ## Security & Configuration Tips
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,36 @@
+* feat: native YDB `UPSERT INTO` for `YDBManager`
+* feat: type query parameters from the expression tree
+* feat: support `TimeField` and pre-1970 dates via YDB's wide signed date/time types
+* feat: support `DecimalField` with arbitrary precision and scale
+* feat: support `__hour`/`__minute`/`__second` lookups on `TimeField`
+* feat: auto-created many-to-many through tables
+* feat: accurate introspection and an explicit schema-operation boundary
+* feat: covering indexes via the `COVER` clause
+* feat: read auto-increment keys via `INSERT ... RETURNING`
+* feat: map `Pi()`, `Random()`, `CURRENT_TIMESTAMP` and `Substr()` to YQL built-ins
+* feat: add an SDK-policy retry helper for interactive transactions
+* fix: correct LIKE/exact lookup escaping for YQL (`ESCAPE '~'`)
+* fix: GROUP BY validation and `aggregate()` parameter binding
+* fix: drop constant GROUP BY/ORDER BY terms and order by aggregate aliases
+* fix: support a nullable expression right-hand side in pattern lookups
+* fix: `bulk_update()` on NOT NULL columns and relation-chain types
+* fix: compose UNION queries under the named-parameter model
+* fix: resolve relation-conformance gaps in DELETE and `dates()`
+* fix: raise `IntegrityError` on NOT NULL violations and reject primary-key-only inserts clearly
+* fix: count UPDATE rows via RETURNING instead of a faked rowcount
+* fix: apply NOT NULL -> nullable in `alter_field`
+* fix: correct schema-editor `db_column` handling
+* fix: emit a LIMIT before OFFSET for open-ended slices
+* fix: audit and correct `DatabaseFeatures` flags
+* docs: define the public support contract and compatibility matrices
+* docs: define and verify the transaction/autocommit contract
+* docs: modernize the bookstore example (DRF + Django contrib)
+* test: gate on Django's bundled database suite across the 4.2/5.2/6.0 matrix
+* test: add migration-executor, Django contrib, and Admin/Auth relationship tests
+* ci: measure backend coverage and upload to Codecov
+* ci: add key-value and transactional SLO workloads
+* ci: require a short CHANGELOG.md entry on pull requests (skip via the 'skip changelog' label)
+
 ## 0.0.1b6 ##
 * fix: support Optional<T> for nullable fields in insert and upsert
 * fix: correct adapt_json_value and add JSONField tests


### PR DESCRIPTION
Hardens the changelog discipline behind the release workflow (#49). The publish workflow reads the entries above the latest `## <version> ##` header, so an empty unreleased section makes it fail right before publishing — which is what has been happening, because no entries accumulate between releases.

## Changes
- **`changelog.yml`** — a `pull_request` check that fails unless the PR edits `CHANGELOG.md` or carries the `skip changelog` label (created on the repo). Re-runs on `labeled`/`unlabeled`, so toggling the label flips the result.
- **AGENTS.md** — documents the rule: every PR adds a short, one-line entry; CI-only/docs-only PRs use the `skip changelog` label.
- **CHANGELOG.md** — backfills the entries accumulated since the `0.0.1b6` release (PRs #60–#111), so the next release (target `0.1.0`) has real notes.

Gating on CI status and a dry-run mode were intentionally left out — releasing stays a manual maintainer action.

Closes #49