### PR TITLE
docs: add a local YDB step to the quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,17 @@ Install:
 pip install django-ydb-backend
 ```
 
-Point a Django database at YDB in `settings.py`:
+To develop against a local database, start YDB in Docker:
+
+```shell
+docker run -d --name ydb-local --hostname localhost \
+  -p 2136:2136 -p 8765:8765 \
+  -e YDB_USE_IN_MEMORY_PDISKS=true \
+  ydbplatform/local-ydb:latest
+```
+
+This serves a ready-to-use database at `/local` on `localhost:2136` — the values
+used below. Then point a Django database at YDB in `settings.py`:
 
 ```python
 DATABASES = {

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,21 @@ Install
 
    pip install django-ydb-backend
 
+Run YDB locally
+~~~~~~~~~~~~~~~~
+
+To develop against a local database, start YDB in Docker:
+
+.. code-block:: bash
+
+   docker run -d --name ydb-local --hostname localhost \
+     -p 2136:2136 -p 8765:8765 \
+     -e YDB_USE_IN_MEMORY_PDISKS=true \
+     ydbplatform/local-ydb:latest
+
+This serves a ready-to-use database at ``/local`` on ``localhost:2136`` — the
+values used in the configuration below.
+
 Configure
 ~~~~~~~~~
 


### PR DESCRIPTION
Adds a "Run YDB locally" step to the quick start (in `index.rst` and `README.md`) so a new user can get a working local database before configuring Django:

```bash
docker run -d --name ydb-local --hostname localhost \
  -p 2136:2136 -p 8765:8765 \
  -e YDB_USE_IN_MEMORY_PDISKS=true \
  ydbplatform/local-ydb:latest
```

The flags mirror the repository's `docker-compose.yml` (`:latest` instead of `:trunk` for users; `--hostname localhost` so a client configured with `HOST: localhost` connects). This serves a ready-to-use database at `/local` on `localhost:2136`, matching the configuration the quick start then shows.

Closes #50