### PR TITLE
test: cover on_commit, pagination, fixtures, admin writes; document select_for_update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* docs: clarify that `select_for_update()` does not lock — YDB uses optimistic concurrency; retry on conflict instead
 * docs: restructure the docs — add a quick start, move the support tables into each topic page, slim the compatibility page, and source the docs version from the package
 * feat: native YDB `UPSERT INTO` for `YDBManager`
 * feat: type query parameters from the expression tree

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -25,7 +25,7 @@ parameters, and UPSERT.
 | `F()`, `Case` / `When` | ✅ | |
 | Window functions (`OVER`) | ✅ | Supports `ROWS BETWEEN N PRECEDING / FOLLOWING`. |
 | `RANGE BETWEEN N PRECEDING …` (bounded offsets) | ❌ | Only unbounded `PRECEDING` / `FOLLOWING` are supported. |
-| `select_for_update(..., limit=...)` | ❌ | Not supported with a limit. |
+| `select_for_update()` | ❌ | A no-op — YDB has no row locking (optimistic concurrency). See [Transactions](TRANSACTIONS.md#row-locking-select-for-update). |
 | Insert into a primary-key-only / multi-table-inheritance table | ❌ | Raises `NotSupportedError` — see [Compatibility](SUPPORT.md). |
 | `ignore_conflicts=True` | ❌ | Not supported. Use UPSERT (below) for race-free writes keyed on the primary key. |
 

--- a/docs/TRANSACTIONS.md
+++ b/docs/TRANSACTIONS.md
@@ -15,6 +15,7 @@ The backend maps Django's transaction API onto YDB's interactive transactions.
 | Django `TestCase` | ❌ | Relies on savepoints — use `TransactionTestCase`. |
 | DDL inside `atomic()` | ❌ | YDB cannot roll back schema changes; migrations run non-atomically. |
 | Automatic retry of `atomic()` blocks | ❌ | Application responsibility — see [Retries](RETRIES.md). |
+| `select_for_update()` (row locking) | ❌ | A no-op — YDB has no pessimistic locks (optimistic concurrency); see below. |
 
 ## What is supported
 
@@ -43,6 +44,30 @@ The backend maps Django's transaction API onto YDB's interactive transactions.
 - **DDL inside `atomic()`.** YDB cannot roll back schema changes, so running DDL
   inside an `atomic()` block raises `TransactionManagementError`. Migrations are
   applied non-atomically for the same reason.
+
+## Row locking (`select_for_update`)
+
+YDB has no pessimistic row locks and no `SELECT ... FOR UPDATE` (YQL rejects the
+syntax), so `QuerySet.select_for_update()` is a **no-op**: it runs as a plain
+`SELECT` and neither locks nor raises (`has_select_for_update = False`, like
+SQLite). You do not lose serialization safety, though — YDB uses optimistic
+concurrency, so a read-modify-write inside `transaction.atomic()` already takes
+optimistic locks on the rows it reads, and a conflicting concurrent write makes
+the **commit** fail with `OperationalError` ("Transaction locks invalidated").
+Re-run the block on conflict instead of locking up front — wrap it with the
+retry helper:
+
+```python
+from django.db import transaction
+from ydb_backend.retry import retry_ydb_errors
+
+@retry_ydb_errors(idempotent=True)
+def reserve_stock(product_id):
+    with transaction.atomic():
+        product = Product.objects.get(pk=product_id)  # optimistically locked
+        product.stock -= 1
+        product.save()
+```
 
 ## Retries and conflicts
 

--- a/tests/backends/ydb/test_fixtures.py
+++ b/tests/backends/ydb/test_fixtures.py
@@ -1,0 +1,43 @@
+import io
+import tempfile
+from pathlib import Path
+
+from django.core.management import call_command
+from django.test import TransactionTestCase
+
+from ..models import SimpleModel
+
+
+class FixturesTest(TransactionTestCase):
+    databases = {"default"}
+
+    def test_dumpdata_loaddata_round_trip(self):
+        # dumpdata serializes the row, then loaddata restores it — the fixture
+        # workflow used for seeding and test data.
+        obj = SimpleModel.objects.create(name="fixture-me")
+
+        buffer = io.StringIO()
+        call_command(
+            "dumpdata",
+            "backends.SimpleModel",
+            "--pks",
+            str(obj.pk),
+            format="json",
+            stdout=buffer,
+        )
+        dumped = buffer.getvalue()
+        self.assertIn("fixture-me", dumped)
+
+        SimpleModel.objects.filter(pk=obj.pk).delete()
+        self.assertFalse(SimpleModel.objects.filter(pk=obj.pk).exists())
+
+        path = Path(tempfile.gettempdir()) / "ydb_fixture_round_trip.json"
+        path.write_text(dumped)
+        try:
+            call_command("loaddata", str(path), verbosity=0)
+        finally:
+            path.unlink()
+
+        self.assertTrue(
+            SimpleModel.objects.filter(pk=obj.pk, name="fixture-me").exists()
+        )

--- a/tests/compiler/test_pagination.py
+++ b/tests/compiler/test_pagination.py
@@ -1,0 +1,26 @@
+from django.core.paginator import Paginator
+from django.test import TransactionTestCase
+
+from .models import Book
+
+
+class PaginatorTest(TransactionTestCase):
+    databases = {"default"}
+
+    def test_count_pages_and_slicing(self):
+        for i in range(5):
+            Book.objects.create(isbn=f"pag-{i}", title=f"t{i}", author="a", price=i)
+        paginator = Paginator(
+            Book.objects.filter(isbn__startswith="pag-").order_by("isbn"), 2
+        )
+        self.assertEqual(paginator.count, 5)
+        self.assertEqual(paginator.num_pages, 3)
+        self.assertEqual(
+            [b.isbn for b in paginator.page(1).object_list], ["pag-0", "pag-1"]
+        )
+        self.assertEqual(
+            [b.isbn for b in paginator.page(2).object_list], ["pag-2", "pag-3"]
+        )
+        self.assertEqual(
+            [b.isbn for b in paginator.page(3).object_list], ["pag-4"]
+        )

--- a/tests/django_contrib/test_smoke.py
+++ b/tests/django_contrib/test_smoke.py
@@ -186,3 +186,30 @@ class TestAdminAuthRelations(TransactionTestCase):
 
         self.assertTrue(null_ok["last_login"])
         self.assertFalse(null_ok["username"])
+
+
+class TestAdminWrites(TransactionTestCase):
+    databases = {"default"}
+
+    def test_admin_create_change_delete_via_forms(self):
+        # The admin write path (ModelForm POSTs) works end to end on YDB, using
+        # the built-in Group admin (add / change / delete).
+        User.objects.create_superuser("admin", "admin@example.com", "secret")
+        client = Client()
+        client.login(username="admin", password="secret")
+
+        add = client.post(
+            "/admin/auth/group/add/", {"name": "editors", "_save": "Save"}
+        )
+        self.assertIn(add.status_code, (200, 302))
+        group = Group.objects.get(name="editors")
+
+        client.post(
+            f"/admin/auth/group/{group.pk}/change/",
+            {"name": "writers", "_save": "Save"},
+        )
+        group.refresh_from_db()
+        self.assertEqual(group.name, "writers")
+
+        client.post(f"/admin/auth/group/{group.pk}/delete/", {"post": "yes"})
+        self.assertFalse(Group.objects.filter(pk=group.pk).exists())

--- a/tests/transactions/test_transactions.py
+++ b/tests/transactions/test_transactions.py
@@ -61,3 +61,40 @@ class TestAtomic(TransactionTestCase):
         with self.assertRaises(TransactionManagementError), transaction.atomic(), \
                 connection.schema_editor() as editor:
             editor.create_model(TxItem)
+
+
+class TestOnCommit(TransactionTestCase):
+    databases = {"default"}
+
+    def test_runs_after_commit(self):
+        fired = []
+        with transaction.atomic():
+            TxItem.objects.create(name="oc")
+            transaction.on_commit(lambda: fired.append("committed"))
+            # The hook has not run yet — still inside the atomic block.
+            self.assertEqual(fired, [])
+        self.assertEqual(fired, ["committed"])
+
+    def test_skipped_on_rollback(self):
+        fired = []
+        with self.assertRaises(ValueError), transaction.atomic():
+            transaction.on_commit(lambda: fired.append("committed"))
+            raise ValueError
+        self.assertEqual(fired, [])
+
+
+class TestSelectForUpdate(TransactionTestCase):
+    databases = {"default"}
+
+    def test_select_for_update_is_a_noop(self):
+        # YDB uses optimistic concurrency and reports has_select_for_update =
+        # False (like SQLite), so select_for_update() runs as a plain SELECT: it
+        # neither locks nor raises. Serialize with ydb_backend.retry instead.
+        self.assertFalse(connection.features.has_select_for_update)
+        TxItem.objects.create(name="sfu")
+        with transaction.atomic():
+            rows = list(TxItem.objects.select_for_update().filter(name="sfu"))
+        self.assertEqual(len(rows), 1)
+        self.assertNotIn(
+            "FOR UPDATE", str(TxItem.objects.select_for_update().query).upper()
+        )


### PR DESCRIPTION
Adds tests for the application-level Django machinery real apps lean on but the conformance gate (core ORM modules) does not exercise, and documents `select_for_update`.

## Tests (all green on YDB)
- **`transaction.on_commit()`** — hook runs after commit, skipped on rollback (`tests/transactions`).
- **`Paginator`** — count / num_pages / slicing (`tests/compiler`).
- **Fixtures** — `dumpdata` → `loaddata` round-trip (`tests/backends/ydb`).
- **Admin writes** — create / change / delete via admin ModelForm POSTs (`tests/django_contrib`).
- **`select_for_update`** — contract test that it is a no-op (no `FOR UPDATE`, no error).

## `select_for_update`
Verified against YDB itself: YQL rejects `SELECT ... FOR UPDATE`/`FOR SHARE`, and YDB has no pessimistic locking — it uses optimistic concurrency (conflicts surface at commit as `OperationalError`, "Transaction locks invalidated"). So `has_select_for_update = False` is correct (same as SQLite), and `select_for_update()` runs as a plain `SELECT`. Docs now explain this and point to the optimistic read-modify-write + retry pattern (`docs/TRANSACTIONS.md`, `docs/OPERATIONS.md`).