### PR TITLE
feat: configurable transaction isolation level via OPTIONS["isolation_level"]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* feat: configurable transaction isolation level via `OPTIONS["isolation_level"]`
 * docs: clarify that `select_for_update()` does not lock — YDB uses optimistic concurrency; retry on conflict instead
 * docs: restructure the docs — add a quick start, move the support tables into each topic page, slim the compatibility page, and source the docs version from the package
 * feat: native YDB `UPSERT INTO` for `YDBManager`

--- a/docs/CONFIGURATIONS.md
+++ b/docs/CONFIGURATIONS.md
@@ -2,7 +2,8 @@ Configurations
 ===
 
 To use the YDB backend you only need to adjust a few of Django's built-in
-database settings — there are no extra YDB-specific configuration options.
+database settings. The single YDB-specific knob is the transaction isolation
+level, set through `OPTIONS` (see below).
 
 ### DATABASES
 
@@ -23,6 +24,42 @@ database settings — there are no extra YDB-specific configuration options.
      }
  }
  ```
+
+### OPTIONS
+
+`OPTIONS` is a dict forwarded to the YDB driver. The backend reads one key,
+`isolation_level`, and passes the rest through to `ydb_dbapi.connect`.
+
+- `isolation_level` (optional): the transaction mode applied to every
+  transaction on the connection. Given as a case-insensitive string; defaults
+  to `"serializable"`. An unknown value raises `ImproperlyConfigured`.
+
+| Value | Reads | Writes |
+|---|---|---|
+| `"serializable"` (default) — interactive, serializable read-write | yes | yes |
+| `"snapshot readonly"` — consistent snapshot | yes | no |
+| `"online readonly"` — latest committed data | yes | no |
+| `"online readonly inconsistent"` — latest data, reads may be inconsistent | yes | no |
+| `"stale readonly"` — possibly stale replica reads (cheapest) | yes | no |
+
+YDB permits writes only under the serializable read-write mode, so the
+read-only modes suit read-only workloads (reporting, analytics): any write —
+`INSERT`/`UPDATE`/`DELETE`, and migrations — is rejected by YDB. Use a
+read-only mode only on a connection you query for reads only, e.g. a second
+`DATABASES` alias pointed at the same database. (The full set of accepted
+values mirrors `ydb_dbapi`'s isolation levels.)
+
+```python
+DATABASES = {
+    "default": {
+        "ENGINE": "ydb_backend.backend",
+        "HOST": "localhost",
+        "PORT": "2136",
+        "DATABASE": "/local",
+        "OPTIONS": {"isolation_level": "serializable"},
+    }
+}
+```
 
 ### Authentication Methods
 

--- a/docs/TRANSACTIONS.md
+++ b/docs/TRANSACTIONS.md
@@ -11,7 +11,10 @@ The backend maps Django's transaction API onto YDB's interactive transactions.
 - **Autocommit** — outside an `atomic()` block every statement is its own
   transaction (the default).
 - The connection stays usable after a rolled-back transaction.
-- The isolation level is `SERIALIZABLE` for interactive transactions.
+- The isolation level is `SERIALIZABLE` for interactive transactions by
+  default. It can be changed per connection with the `isolation_level`
+  `OPTIONS` setting (see [Configurations](CONFIGURATIONS.md)); note that the
+  non-serializable modes are read-only and reject writes.
 
 ## What is not supported
 

--- a/tests/backends/ydb/test_base.py
+++ b/tests/backends/ydb/test_base.py
@@ -4,7 +4,9 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db import connection
 from django.db.utils import NotSupportedError
 from django.test import SimpleTestCase
+from ydb_backend.backend import base
 from ydb_backend.backend.base import DatabaseWrapper
+from ydb_dbapi import IsolationLevel
 
 
 class TestDatabaseWrapper(SimpleTestCase):
@@ -70,8 +72,80 @@ class TestConnectionParams(SimpleTestCase):
         self.assertEqual(params["credentials"], "token")
         self.assertEqual(params["root_certificates_path"], "/certs/ca.pem")
 
+    def test_no_isolation_level_by_default(self):
+        params = self.params(HOST="localhost", PORT="2136", DATABASE="/local")
+        self.assertNotIn("isolation_level", params)
+
+    def test_isolation_level_mapped_to_enum(self):
+        params = self.params(
+            HOST="localhost",
+            PORT="2136",
+            DATABASE="/local",
+            OPTIONS={"isolation_level": "snapshot readonly"},
+        )
+        self.assertEqual(params["isolation_level"], IsolationLevel.SNAPSHOT_READONLY)
+
+    def test_isolation_level_normalization_is_lenient(self):
+        for value in ("SERIALIZABLE", "serializable", "Serializable"):
+            params = self.params(
+                HOST="localhost",
+                PORT="2136",
+                DATABASE="/local",
+                OPTIONS={"isolation_level": value},
+            )
+            self.assertEqual(params["isolation_level"], IsolationLevel.SERIALIZABLE)
+        # Enum member spelling (underscores) is accepted too.
+        params = self.params(
+            HOST="localhost",
+            PORT="2136",
+            DATABASE="/local",
+            OPTIONS={"isolation_level": "online_readonly_inconsistent"},
+        )
+        self.assertEqual(
+            params["isolation_level"],
+            IsolationLevel.ONLINE_READONLY_INCONSISTENT,
+        )
+
+    def test_unknown_isolation_level_raises(self):
+        with self.assertRaisesMessage(ImproperlyConfigured, "isolation_level"):
+            self.params(
+                HOST="localhost",
+                PORT="2136",
+                DATABASE="/local",
+                OPTIONS={"isolation_level": "repeatable read"},
+            )
+
     def test_is_usable_false_without_connection(self):
         self.assertFalse(DatabaseWrapper.is_usable(SimpleNamespace(connection=None)))
+
+
+class TestNewConnectionIsolationLevel(SimpleTestCase):
+    def test_isolation_level_applied_and_not_forwarded_to_connect(self):
+        recorded = {}
+
+        class FakeConnection:
+            def set_isolation_level(self, level):
+                recorded["level"] = level
+
+        def fake_connect(**kwargs):
+            recorded["connect_kwargs"] = kwargs
+            return FakeConnection()
+
+        conn_params = {
+            "host": "localhost",
+            "port": "2136",
+            "database": "/local",
+            "isolation_level": IsolationLevel.SNAPSHOT_READONLY,
+        }
+        original_connect = base.Database.connect
+        base.Database.connect = fake_connect
+        try:
+            DatabaseWrapper.get_new_connection(SimpleNamespace(), conn_params)
+        finally:
+            base.Database.connect = original_connect
+
+        self.assertEqual(recorded["level"], IsolationLevel.SNAPSHOT_READONLY)
+        self.assertNotIn("isolation_level", recorded["connect_kwargs"])
 
 
 class TestDatabaseVersion(SimpleTestCase):

--- a/tests/backends/ydb/test_base.py
+++ b/tests/backends/ydb/test_base.py
@@ -106,6 +106,15 @@ class TestConnectionParams(SimpleTestCase):
             IsolationLevel.ONLINE_READONLY_INCONSISTENT,
         )
 
+    def test_isolation_level_accepts_enum_instance(self):
+        params = self.params(
+            HOST="localhost",
+            PORT="2136",
+            DATABASE="/local",
+            OPTIONS={"isolation_level": IsolationLevel.STALE_READONLY},
+        )
+        self.assertEqual(params["isolation_level"], IsolationLevel.STALE_READONLY)
+
     def test_unknown_isolation_level_raises(self):
         with self.assertRaisesMessage(ImproperlyConfigured, "isolation_level"):
             self.params(

--- a/ydb_backend/backend/base.py
+++ b/ydb_backend/backend/base.py
@@ -35,6 +35,31 @@ from .schema import DatabaseSchemaEditor
 from .validation import DatabaseValidation
 
 
+def _normalize_isolation_level(value):
+    """
+    Map a ``DATABASES["OPTIONS"]["isolation_level"]`` setting to a ydb_dbapi
+    ``IsolationLevel``.
+
+    The level is given as a case-insensitive string (e.g. ``"serializable"`` or
+    ``"snapshot readonly"``); underscores are treated as spaces so the enum
+    member spelling works too. Raise ``ImproperlyConfigured`` for an unknown
+    level so misconfiguration fails fast at connect time.
+    """
+    levels = Database.IsolationLevel
+    if isinstance(value, levels):
+        return value
+    normalized = " ".join(str(value).upper().replace("_", " ").split())
+    try:
+        return levels(normalized)
+    except ValueError:
+        allowed = ", ".join(sorted(level.value.lower() for level in levels))
+        msg = (
+            f"Unknown isolation_level {value!r} in DATABASES OPTIONS for the "
+            f"YDB backend. Supported values: {allowed}."
+        )
+        raise ImproperlyConfigured(msg) from None
+
+
 class DatabaseWrapper(BaseDatabaseWrapper):
     """
     Represent a database connection.
@@ -77,7 +102,6 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         "UUIDField": "UUID",
         "JSONField": "Json",
         "EnumField": "Enum",
-
         # TODO: Add validation for string related fields
         # FileField/ImageField store a text path, not raw bytes, so Utf8.
         "FileField": "Utf8",
@@ -236,13 +260,18 @@ class DatabaseWrapper(BaseDatabaseWrapper):
                 "YDB database is not configured. Set 'DATABASE' in DATABASES."
             )
 
+        options = dict(settings_dict.get("OPTIONS", {}))
+        isolation_level = options.pop("isolation_level", None)
+
         conn_params = {
             "host": settings_dict["HOST"],
             "port": settings_dict["PORT"],
             "database": settings_dict["DATABASE"],
-            **settings_dict.get("OPTIONS", {}),
+            **options,
         }
 
+        if isolation_level is not None:
+            conn_params["isolation_level"] = _normalize_isolation_level(isolation_level)
         if settings_dict.get("CREDENTIALS"):
             conn_params["credentials"] = settings_dict["CREDENTIALS"]
         if settings_dict.get("ROOT_CERTIFICATES_PATH"):
@@ -256,6 +285,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         """
         Open a connection to the database.
         """
+        isolation_level = conn_params.pop("isolation_level", None)
         try:
             logger.debug(f"Connecting to YDB with params: {conn_params}")
             connection = Database.connect(**conn_params)
@@ -265,6 +295,12 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             msg = f"Failed to connect to YDB: {e}"
             raise OperationalError(msg) from e
         else:
+            # Set the transaction mode for the connection. ``_set_autocommit``
+            # keeps driving ``interactive_transaction`` from there on, so only
+            # the tx mode needs to persist. Read-only modes (snapshot/online/
+            # stale) accept reads only; writes are rejected by YDB.
+            if isolation_level is not None:
+                connection.set_isolation_level(isolation_level)
             return connection
 
     def create_cursor(self, name=None):


### PR DESCRIPTION
## Summary

Lets users set the YDB transaction isolation level through `DATABASES["OPTIONS"]["isolation_level"]`, the same way PostgreSQL and MySQL expose it. Previously the backend ignored any isolation setting and always used the driver default (`SerializableReadWrite`).

The value is a **case-insensitive string** (e.g. `"serializable"`, `"snapshot readonly"`) mapped internally to `ydb_dbapi.IsolationLevel`, so users don't have to import internal enums. An unknown value raises `ImproperlyConfigured` at connect time.

```python
DATABASES = {
    "default": {
        "ENGINE": "ydb_backend.backend",
        "OPTIONS": {"isolation_level": "snapshot readonly"},
        ...
    }
}
```

## Details

- `get_connection_params` pops `isolation_level` out of `OPTIONS`, normalizes and validates it; the rest of `OPTIONS` is still forwarded to the driver untouched.
- `get_new_connection` applies it via `connection.set_isolation_level(...)` after connecting (and never forwards the key to `ydb_dbapi.connect`).
- `_set_autocommit` keeps driving `interactive_transaction`, so only the tx mode needs to persist — autocommit/`atomic()` behavior is unchanged for the default.

## Caveat (documented)

YDB permits writes only under the serializable read-write mode. The read-only modes (snapshot / online / stale) are for read-only workloads — any write, including migrations, is rejected by YDB. Docs (`CONFIGURATIONS.md`, `TRANSACTIONS.md`) spell this out.